### PR TITLE
db(schema): 보호자/어르신 시스템 DB 스키마 확장

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -1,12 +1,33 @@
+-- =============================================================================
+-- OPS Backend Database Schema
+-- Version: 2.0.0 (보호자/어르신 시스템 확장)
+-- =============================================================================
+
 create extension if not exists pgcrypto;
 
+-- =============================================================================
+-- 1. USERS (사용자) - 확장됨
+-- =============================================================================
 create table if not exists users (
   id uuid primary key default gen_random_uuid(),
   identity text unique not null,
   display_name text,
-  created_at timestamptz not null default now()
+  user_type text,  -- 'guardian' | 'ward' | null (관제센터 등)
+  email text unique,
+  nickname text,
+  profile_image_url text,
+  kakao_id text unique,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
 );
 
+create index if not exists idx_users_email on users(email);
+create index if not exists idx_users_kakao_id on users(kakao_id);
+create index if not exists idx_users_user_type on users(user_type);
+
+-- =============================================================================
+-- 2. DEVICES (디바이스)
+-- =============================================================================
 create table if not exists devices (
   id uuid primary key default gen_random_uuid(),
   user_id uuid references users(id) on delete cascade,
@@ -24,6 +45,60 @@ create table if not exists devices (
 create index if not exists idx_devices_user_id on devices(user_id);
 create index if not exists idx_devices_env on devices(env);
 
+-- =============================================================================
+-- 3. ORGANIZATIONS (기관)
+-- =============================================================================
+create table if not exists organizations (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  created_at timestamptz not null default now()
+);
+
+-- =============================================================================
+-- 4. GUARDIANS (보호자 추가 정보)
+-- =============================================================================
+create table if not exists guardians (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid unique references users(id) on delete cascade,
+  ward_email text not null,
+  ward_phone_number text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_guardians_user_id on guardians(user_id);
+create index if not exists idx_guardians_ward_email on guardians(ward_email);
+
+-- =============================================================================
+-- 5. WARDS (어르신/피보호자 추가 정보)
+-- =============================================================================
+create table if not exists wards (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid unique references users(id) on delete cascade,
+  phone_number text not null,
+  guardian_id uuid references guardians(id) on delete set null,
+  organization_id uuid references organizations(id) on delete set null,
+  ai_persona text default '다미',
+  weekly_call_count int default 3,
+  call_duration_minutes int default 15,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  -- 보호자 또는 기관 중 하나만 연결 (또는 둘 다 없음)
+  constraint chk_ward_link check (
+    (guardian_id is not null and organization_id is null) or
+    (guardian_id is null and organization_id is not null) or
+    (guardian_id is null and organization_id is null)
+  )
+);
+
+create index if not exists idx_wards_user_id on wards(user_id);
+create index if not exists idx_wards_guardian_id on wards(guardian_id);
+create index if not exists idx_wards_organization_id on wards(organization_id);
+
+-- =============================================================================
+-- 6. ROOMS (통화방)
+-- =============================================================================
 create table if not exists rooms (
   id uuid primary key default gen_random_uuid(),
   room_name text unique not null,
@@ -31,6 +106,9 @@ create table if not exists rooms (
   created_at timestamptz not null default now()
 );
 
+-- =============================================================================
+-- 7. CALLS (통화 기록)
+-- =============================================================================
 create table if not exists calls (
   call_id uuid primary key default gen_random_uuid(),
   caller_user_id uuid references users(id) on delete set null,
@@ -47,6 +125,9 @@ create table if not exists calls (
 create index if not exists idx_calls_callee_state on calls(callee_identity, state);
 create index if not exists idx_calls_room_name on calls(room_name);
 
+-- =============================================================================
+-- 8. ROOM_MEMBERS (방 참여자)
+-- =============================================================================
 create table if not exists room_members (
   id uuid primary key default gen_random_uuid(),
   room_id uuid references rooms(id) on delete cascade,
@@ -57,3 +138,68 @@ create table if not exists room_members (
 
 create index if not exists idx_room_members_room_id on room_members(room_id);
 create unique index if not exists uq_room_members_room_user on room_members(room_id, user_id);
+
+-- =============================================================================
+-- 9. CALL_SUMMARIES (통화 요약/분석)
+-- =============================================================================
+create table if not exists call_summaries (
+  id uuid primary key default gen_random_uuid(),
+  call_id uuid references calls(call_id) on delete cascade,
+  ward_id uuid references wards(id) on delete cascade,
+  summary text,
+  mood text,  -- 'positive' | 'neutral' | 'negative'
+  mood_score decimal(3,2),  -- 0.00 ~ 1.00
+  tags text[],  -- ['날씨', '손주', '건강']
+  health_keywords jsonb,  -- {"pain": 2, "sleep": "good"}
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_call_summaries_call_id on call_summaries(call_id);
+create index if not exists idx_call_summaries_ward_id on call_summaries(ward_id);
+create index if not exists idx_call_summaries_created_at on call_summaries(created_at);
+
+-- =============================================================================
+-- 10. HEALTH_ALERTS (건강 알림)
+-- =============================================================================
+create table if not exists health_alerts (
+  id uuid primary key default gen_random_uuid(),
+  ward_id uuid references wards(id) on delete cascade,
+  guardian_id uuid references guardians(id) on delete cascade,
+  alert_type text not null,  -- 'warning' | 'info'
+  message text not null,
+  is_read boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_health_alerts_guardian_id on health_alerts(guardian_id);
+create index if not exists idx_health_alerts_ward_id on health_alerts(ward_id);
+create index if not exists idx_health_alerts_is_read on health_alerts(is_read);
+
+-- =============================================================================
+-- 11. NOTIFICATION_SETTINGS (알림 설정)
+-- =============================================================================
+create table if not exists notification_settings (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid unique references users(id) on delete cascade,
+  call_reminder boolean not null default true,
+  call_complete boolean not null default true,
+  health_alert boolean not null default true,
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_notification_settings_user_id on notification_settings(user_id);
+
+-- =============================================================================
+-- 12. REFRESH_TOKENS (리프레시 토큰)
+-- =============================================================================
+create table if not exists refresh_tokens (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references users(id) on delete cascade,
+  token_hash text unique not null,
+  expires_at timestamptz not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_refresh_tokens_user_id on refresh_tokens(user_id);
+create index if not exists idx_refresh_tokens_expires_at on refresh_tokens(expires_at);
+create index if not exists idx_refresh_tokens_token_hash on refresh_tokens(token_hash);


### PR DESCRIPTION
## 변경 사항

보호자/어르신 시스템을 위한 DB 스키마 확장

### 추가된 테이블
- `organizations` - 기관 정보
- `guardians` - 보호자 추가 정보
- `wards` - 어르신/피보호자 추가 정보
- `call_summaries` - 통화 요약 및 AI 분석 결과
- `health_alerts` - 건강 알림
- `notification_settings` - 알림 설정
- `refresh_tokens` - JWT 리프레시 토큰

### 확장된 테이블
- `users` - user_type, email, nickname, profile_image_url, kakao_id 컬럼 추가

### 타입 정의
- `db.service.ts`에 새 테이블 Row 타입 추가 (GuardianRow, WardRow, OrganizationRow, RefreshTokenRow)
- UserRow 타입 확장

## 변경된 파일

- `db/init.sql` - 스키마 정의
- `api/src/db.service.ts` - 타입 정의

## 체크리스트

- [x] Docker 빌드 성공 확인
- [x] 스키마 문법 검증

## Merge 가이드

- Target: `develop`
- Squash and Merge 권장

Closes #1
