### PR TITLE
feat(auth): JWT 토큰 갱신 API 구현

### DIFF
--- a/api/src/app.controller.ts
+++ b/api/src/app.controller.ts
@@ -61,6 +61,29 @@ export class AppController {
     }
   }
 
+  @Post('/v1/auth/refresh')
+  async authRefresh(@Body() body: { refreshToken?: string }) {
+    const refreshToken = body.refreshToken?.trim();
+    if (!refreshToken) {
+      throw new HttpException('refreshToken is required', HttpStatus.BAD_REQUEST);
+    }
+
+    try {
+      this.logger.log('authRefresh');
+      const tokens = await this.authService.refreshTokens(refreshToken);
+      return tokens;
+    } catch (error) {
+      if ((error as HttpException).getStatus?.() === HttpStatus.UNAUTHORIZED) {
+        throw error;
+      }
+      this.logger.warn(`authRefresh failed error=${(error as Error).message}`);
+      throw new HttpException(
+        (error as Error).message || 'Token refresh failed',
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+  }
+
   @Get('/v1/rooms/:roomName/members')
   async listRoomMembers(
     @Headers('authorization') authorization: string | undefined,


### PR DESCRIPTION
## Summary
- Refresh Token을 사용하여 Access Token 재발급
- Token Rotation 지원 (보안 강화)

## Changes
- `auth.service.ts`에 `refreshTokens` 메서드 추가
- `app.controller.ts`에 `/v1/auth/refresh` 엔드포인트 추가

## API
**POST /v1/auth/refresh**
```json
{
  "refreshToken": "jwt..."
}
```

**Response:**
```json
{
  "accessToken": "jwt...",
  "refreshToken": "jwt..."
}
```

## Test plan
- [ ] 유효한 refresh token으로 토큰 갱신 테스트
- [ ] 만료된 토큰으로 요청 시 401 응답 확인
- [ ] Token Rotation 동작 확인 (기존 토큰 무효화)

Closes #3