### PR TITLE
feat(auth): 보호자 회원가입 API 구현

### DIFF
--- a/api/src/db.service.ts
+++ b/api/src/db.service.ts
@@ -456,6 +456,20 @@ export class DbService implements OnModuleInit, OnModuleDestroy {
     return result.rows[0];
   }
 
+  async createGuardian(params: {
+    userId: string;
+    wardEmail: string;
+    wardPhoneNumber: string;
+  }) {
+    const result = await this.pool.query<GuardianRow>(
+      `insert into guardians (user_id, ward_email, ward_phone_number, updated_at)
+       values ($1, $2, $3, now())
+       returning id, user_id, ward_email, ward_phone_number, created_at, updated_at`,
+      [params.userId, params.wardEmail, params.wardPhoneNumber],
+    );
+    return result.rows[0];
+  }
+
   async saveRefreshToken(params: {
     userId: string;
     tokenHash: string;


### PR DESCRIPTION
## Summary
- 카카오 로그인 후 보호자 회원가입 API 구현
- 피보호자 이메일 및 전화번호 등록

## Changes
- `db.service.ts`에 `createGuardian` 메서드 추가
- `auth.service.ts`에 `registerGuardian` 메서드 추가
- `app.controller.ts`에 `/v1/users/register/guardian` 엔드포인트 추가

## API
**POST /v1/users/register/guardian**

Headers:
```
Authorization: Bearer {tempToken}
```

Request:
```json
{
  "wardEmail": "ward@email.com",
  "wardPhoneNumber": "010-1234-5678"
}
```

Response:
```json
{
  "accessToken": "jwt...",
  "refreshToken": "jwt...",
  "user": { ... },
  "guardianInfo": { ... }
}
```

## Test plan
- [ ] 유효한 temp token으로 회원가입 테스트
- [ ] 잘못된 이메일/전화번호 형식 검증 테스트
- [ ] 중복 회원가입 방지 테스트

Closes #4