### PR TITLE
feat(api): 푸시 알림 스케줄링 (Issue #12)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/common": "^11.0.1",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/schedule": "^5.0.1",
         "apn": "^2.2.0",
         "jsonwebtoken": "^9.0.3",
         "livekit-server-sdk": "^2.15.0",
@@ -2415,6 +2416,19 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-5.0.1.tgz",
+      "integrity": "sha512-kFoel84I4RyS2LNPH6yHYTKxB16tb3auAEciFuc788C3ph6nABkUfzX5IE+unjVaRX+3GuruJwurNepMlHXpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "3.5.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.9",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.9.tgz",
@@ -2882,6 +2896,12 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -4881,6 +4901,16 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.5.0.tgz",
+      "integrity": "sha512-0eYZqCnapmxYcV06uktql93wNWdlTmmBFP2iYz+JPVcQqlyFYcn1lFuIk4R54pkOmE7mcldTAPZv6X5XA4Q46A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.4.0",
+        "luxon": "~3.5.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7590,6 +7620,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/api/package.json
+++ b/api/package.json
@@ -23,6 +23,7 @@
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^5.0.1",
     "apn": "^2.2.0",
     "jsonwebtoken": "^9.0.3",
     "livekit-server-sdk": "^2.15.0",

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,13 +1,15 @@
 import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthService } from './auth.service';
 import { DbService } from './db.service';
 import { PushService } from './push.service';
+import { NotificationScheduler } from './notification.scheduler';
 
 @Module({
-  imports: [],
+  imports: [ScheduleModule.forRoot()],
   controllers: [AppController],
-  providers: [AppService, AuthService, DbService, PushService],
+  providers: [AppService, AuthService, DbService, PushService, NotificationScheduler],
 })
 export class AppModule {}

--- a/api/src/notification.scheduler.ts
+++ b/api/src/notification.scheduler.ts
@@ -1,0 +1,108 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { DbService } from './db.service';
+import { AppService } from './app.service';
+
+@Injectable()
+export class NotificationScheduler {
+  private readonly logger = new Logger(NotificationScheduler.name);
+
+  constructor(
+    private readonly dbService: DbService,
+    private readonly appService: AppService,
+  ) {}
+
+  // 매 30분마다 리마인더 체크 (예: 09:00, 09:30, 10:00, ...)
+  @Cron(CronExpression.EVERY_30_MINUTES)
+  async checkCallReminders() {
+    const now = new Date();
+    const dayOfWeek = now.getDay(); // 0=일, 1=월, ..., 6=토
+    const currentHour = now.getHours();
+    const currentMinute = now.getMinutes();
+
+    // 30분 후 예정된 통화 확인
+    const targetTime = new Date(now.getTime() + 30 * 60 * 1000);
+    const startTime = `${String(currentHour).padStart(2, '0')}:${String(currentMinute).padStart(2, '0')}:00`;
+    const endTime = `${String(targetTime.getHours()).padStart(2, '0')}:${String(targetTime.getMinutes()).padStart(2, '0')}:00`;
+
+    this.logger.log(`checkCallReminders dayOfWeek=${dayOfWeek} timeRange=${startTime}-${endTime}`);
+
+    try {
+      const schedules = await this.dbService.getUpcomingCallSchedules(dayOfWeek, startTime, endTime);
+
+      for (const schedule of schedules) {
+        // 어르신에게 리마인더 푸시
+        await this.appService.sendUserPush({
+          identity: schedule.ward_identity,
+          type: 'alert',
+          title: '담소',
+          body: `30분 후 ${schedule.ai_persona}와 대화 예정이에요`,
+          payload: { type: 'call_reminder', scheduleId: schedule.id },
+        });
+
+        // 리마인더 전송 완료 기록
+        await this.dbService.markReminderSent(schedule.id);
+
+        this.logger.log(`checkCallReminders sent wardIdentity=${schedule.ward_identity} scheduleId=${schedule.id}`);
+      }
+    } catch (error) {
+      this.logger.error(`checkCallReminders failed error=${(error as Error).message}`);
+    }
+  }
+
+  // 매 시간 미진행 통화 체크
+  @Cron(CronExpression.EVERY_HOUR)
+  async checkMissedCalls() {
+    this.logger.log('checkMissedCalls started');
+
+    try {
+      const missedCalls = await this.dbService.getMissedCalls(1);
+
+      for (const missed of missedCalls) {
+        // 보호자에게 미진행 알림
+        await this.appService.sendUserPush({
+          identity: missed.guardian_identity,
+          type: 'alert',
+          title: '담소',
+          body: '어르신이 오늘 예정된 통화를 하지 않으셨어요',
+          payload: { type: 'missed_call', wardId: missed.ward_id },
+        });
+
+        this.logger.log(`checkMissedCalls sent guardianIdentity=${missed.guardian_identity} wardId=${missed.ward_id}`);
+      }
+    } catch (error) {
+      this.logger.error(`checkMissedCalls failed error=${(error as Error).message}`);
+    }
+  }
+
+  // 통화 종료 시 보호자에게 알림 (AppService에서 호출)
+  async notifyCallComplete(callId: string) {
+    try {
+      const callInfo = await this.dbService.getCallWithWardInfo(callId);
+      if (!callInfo || !callInfo.guardian_identity || !callInfo.guardian_user_id) {
+        this.logger.log(`notifyCallComplete no guardian callId=${callId}`);
+        return;
+      }
+
+      // 보호자 알림 설정 확인
+      const settings = await this.dbService.getGuardianNotificationSettings(callInfo.guardian_user_id);
+      if (!settings.call_complete) {
+        this.logger.log(`notifyCallComplete disabled callId=${callId} guardianUserId=${callInfo.guardian_user_id}`);
+        return;
+      }
+
+      const aiPersona = callInfo.ward_ai_persona || '다미';
+      await this.appService.sendUserPush({
+        identity: callInfo.guardian_identity,
+        type: 'alert',
+        title: '담소',
+        body: `어르신과 ${aiPersona}의 대화가 끝났어요`,
+        payload: { type: 'call_complete', callId },
+      });
+
+      this.logger.log(`notifyCallComplete sent callId=${callId} guardianIdentity=${callInfo.guardian_identity}`);
+    } catch (error) {
+      this.logger.error(`notifyCallComplete failed callId=${callId} error=${(error as Error).message}`);
+    }
+  }
+}

--- a/db/init.sql
+++ b/db/init.sql
@@ -222,3 +222,23 @@ create table if not exists guardian_ward_registrations (
 create index if not exists idx_gwr_guardian_id on guardian_ward_registrations(guardian_id);
 create index if not exists idx_gwr_ward_email on guardian_ward_registrations(ward_email);
 create index if not exists idx_gwr_linked_ward_id on guardian_ward_registrations(linked_ward_id);
+
+-- =============================================================================
+-- 14. CALL_SCHEDULES (예약 통화)
+-- =============================================================================
+-- 어르신별 정기 통화 스케줄
+create table if not exists call_schedules (
+  id uuid primary key default gen_random_uuid(),
+  ward_id uuid references wards(id) on delete cascade,
+  day_of_week int not null,  -- 0=일, 1=월, ..., 6=토
+  scheduled_time time not null,  -- 예: '10:00:00'
+  is_active boolean not null default true,
+  last_called_at timestamptz,
+  reminder_sent_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_call_schedules_ward_id on call_schedules(ward_id);
+create index if not exists idx_call_schedules_day_of_week on call_schedules(day_of_week);
+create index if not exists idx_call_schedules_is_active on call_schedules(is_active);


### PR DESCRIPTION
## Summary
- @nestjs/schedule 패키지를 사용한 Cron 기반 푸시 알림 스케줄링
- 통화 리마인더, 미진행 통화 알림, 통화 완료 알림 기능 추가
- call_schedules 테이블 추가로 정기 통화 스케줄 관리

## Changes

### New Files
- `api/src/notification.scheduler.ts`: 알림 스케줄러 서비스

### Modified Files
- `api/package.json`: @nestjs/schedule 의존성 추가
- `api/src/app.module.ts`: ScheduleModule 및 NotificationScheduler 등록
- `api/src/app.controller.ts`: 통화 종료 시 보호자 알림 연동
- `api/src/db.service.ts`: 스케줄링 관련 DB 메서드 추가
- `db/init.sql`: call_schedules 테이블 추가

## Features

### 1. 통화 리마인더 (매 30분)
- 30분 내 예정된 통화 확인
- 어르신에게 리마인더 푸시 전송
- 중복 전송 방지 (reminder_sent_at 체크)

### 2. 미진행 통화 알림 (매 시간)
- 1시간 전 예정 통화 중 미진행 건 확인
- 보호자에게 알림 푸시 전송

### 3. 통화 완료 알림 (이벤트 기반)
- POST /v1/calls/end 호출 시 비동기 실행
- 보호자 알림 설정 확인 후 전송
- 연결된 보호자에게 통화 완료 알림

## DB Schema
```sql
-- call_schedules 테이블
create table call_schedules (
  id uuid primary key,
  ward_id uuid references wards(id),
  day_of_week int not null,  -- 0=일, 1=월, ..., 6=토
  scheduled_time time not null,
  is_active boolean default true,
  last_called_at timestamptz,
  reminder_sent_at timestamptz,
  ...
);
```

## Test plan
- [ ] 통화 종료 시 보호자에게 알림 전송 확인
- [ ] 보호자 알림 설정 비활성화 시 알림 미전송 확인
- [ ] Cron job 정상 등록 확인 (로그)

Closes #12