### PR TITLE
feat(api,web): 실시간 위치정보 API + Naver Map 연동 (Issue #15)

### DIFF
--- a/api/src/db.service.ts
+++ b/api/src/db.service.ts
@@ -1362,4 +1362,171 @@ export class DbService implements OnModuleInit, OnModuleDestroy {
     );
     return result.rows;
   }
+
+  // ============================================================
+  // Ward Location methods
+  // ============================================================
+
+  async createWardLocation(params: {
+    wardId: string;
+    latitude: number;
+    longitude: number;
+    accuracy: number | null;
+    recordedAt: Date;
+  }) {
+    const result = await this.pool.query<{
+      id: string;
+      ward_id: string;
+      latitude: string;
+      longitude: string;
+      accuracy: string | null;
+      recorded_at: string;
+      created_at: string;
+    }>(
+      `insert into ward_locations (ward_id, latitude, longitude, accuracy, recorded_at)
+       values ($1, $2, $3, $4, $5)
+       returning id, ward_id, latitude, longitude, accuracy, recorded_at, created_at`,
+      [
+        params.wardId,
+        params.latitude,
+        params.longitude,
+        params.accuracy,
+        params.recordedAt.toISOString(),
+      ],
+    );
+    return result.rows[0];
+  }
+
+  async upsertWardCurrentLocation(params: {
+    wardId: string;
+    latitude: number;
+    longitude: number;
+    accuracy: number | null;
+    status?: 'normal' | 'warning' | 'emergency';
+  }) {
+    const status = params.status || 'normal';
+    const result = await this.pool.query<{
+      ward_id: string;
+      latitude: string;
+      longitude: string;
+      accuracy: string | null;
+      status: string;
+      last_updated: string;
+    }>(
+      `insert into ward_current_locations (ward_id, latitude, longitude, accuracy, status, last_updated)
+       values ($1, $2, $3, $4, $5, now())
+       on conflict (ward_id)
+       do update set
+         latitude = excluded.latitude,
+         longitude = excluded.longitude,
+         accuracy = excluded.accuracy,
+         status = excluded.status,
+         last_updated = now()
+       returning ward_id, latitude, longitude, accuracy, status, last_updated`,
+      [params.wardId, params.latitude, params.longitude, params.accuracy, status],
+    );
+    return result.rows[0];
+  }
+
+  async getAllWardCurrentLocations(organizationId?: string) {
+    let query = `
+      select
+        wcl.ward_id,
+        w.user_id,
+        u.display_name as ward_name,
+        u.nickname as ward_nickname,
+        wcl.latitude,
+        wcl.longitude,
+        wcl.accuracy,
+        wcl.status,
+        wcl.last_updated,
+        w.organization_id
+      from ward_current_locations wcl
+      join wards w on wcl.ward_id = w.id
+      join users u on w.user_id = u.id
+    `;
+    const values: string[] = [];
+
+    if (organizationId) {
+      query += ` where w.organization_id = $1`;
+      values.push(organizationId);
+    }
+
+    query += ` order by wcl.last_updated desc`;
+
+    const result = await this.pool.query<{
+      ward_id: string;
+      user_id: string;
+      ward_name: string | null;
+      ward_nickname: string | null;
+      latitude: string;
+      longitude: string;
+      accuracy: string | null;
+      status: string;
+      last_updated: string;
+      organization_id: string | null;
+    }>(query, values);
+
+    return result.rows;
+  }
+
+  async getWardLocationHistory(params: {
+    wardId: string;
+    from?: Date;
+    to?: Date;
+    limit?: number;
+  }) {
+    const values: (string | number)[] = [params.wardId];
+    let whereClause = 'where ward_id = $1';
+    let paramIndex = 2;
+
+    if (params.from) {
+      whereClause += ` and recorded_at >= $${paramIndex++}`;
+      values.push(params.from.toISOString());
+    }
+
+    if (params.to) {
+      whereClause += ` and recorded_at <= $${paramIndex++}`;
+      values.push(params.to.toISOString());
+    }
+
+    const limit = params.limit || 100;
+    values.push(limit);
+
+    const result = await this.pool.query<{
+      id: string;
+      latitude: string;
+      longitude: string;
+      accuracy: string | null;
+      recorded_at: string;
+    }>(
+      `select id, latitude, longitude, accuracy, recorded_at
+       from ward_locations
+       ${whereClause}
+       order by recorded_at desc
+       limit $${paramIndex}`,
+      values,
+    );
+
+    return result.rows;
+  }
+
+  async findWardById(wardId: string) {
+    const result = await this.pool.query<WardRow>(
+      `select id, user_id, phone_number, guardian_id, organization_id, ai_persona,
+              weekly_call_count, call_duration_minutes, created_at, updated_at
+       from wards
+       where id = $1
+       limit 1`,
+      [wardId],
+    );
+    return result.rows[0];
+  }
+
+  async updateWardLocationStatus(wardId: string, status: 'normal' | 'warning' | 'emergency') {
+    await this.pool.query(
+      `update ward_current_locations set status = $2, last_updated = now() where ward_id = $1`,
+      [wardId, status],
+    );
+  }
 }

--- a/db/init.sql
+++ b/db/init.sql
@@ -266,3 +266,36 @@ create table if not exists organization_wards (
 create index if not exists idx_org_wards_org_id on organization_wards(organization_id);
 create index if not exists idx_org_wards_email on organization_wards(email);
 create index if not exists idx_org_wards_is_registered on organization_wards(is_registered);
+
+-- =============================================================================
+-- 16. WARD_LOCATIONS (피보호자 위치 이력)
+-- =============================================================================
+-- 모바일에서 전송받은 피보호자 실시간 위치정보 이력
+create table if not exists ward_locations (
+  id uuid primary key default gen_random_uuid(),
+  ward_id uuid references wards(id) on delete cascade,
+  latitude decimal(10, 8) not null,
+  longitude decimal(11, 8) not null,
+  accuracy decimal(6, 2),
+  recorded_at timestamptz not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_ward_locations_ward_id on ward_locations(ward_id);
+create index if not exists idx_ward_locations_recorded_at on ward_locations(recorded_at);
+create index if not exists idx_ward_locations_ward_recorded on ward_locations(ward_id, recorded_at desc);
+
+-- =============================================================================
+-- 17. WARD_CURRENT_LOCATIONS (피보호자 최신 위치)
+-- =============================================================================
+-- 최신 위치만 빠르게 조회하기 위한 테이블
+create table if not exists ward_current_locations (
+  ward_id uuid primary key references wards(id) on delete cascade,
+  latitude decimal(10, 8) not null,
+  longitude decimal(11, 8) not null,
+  accuracy decimal(6, 2),
+  status text not null default 'normal',  -- 'normal' | 'warning' | 'emergency'
+  last_updated timestamptz not null
+);
+
+create index if not exists idx_ward_current_locations_status on ward_current_locations(status);

--- a/web/app/locations/page.tsx
+++ b/web/app/locations/page.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { LocationMap, type WardLocation } from "../../components/LocationMap";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
+export default function LocationsPage() {
+  const [locations, setLocations] = useState<WardLocation[]>([]);
+  const [selectedWardId, setSelectedWardId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [autoRefresh, setAutoRefresh] = useState(true);
+
+  const fetchLocations = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_BASE}/v1/admin/locations`);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = await response.json();
+      setLocations(data.locations || []);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchLocations();
+
+    // Auto refresh every 30 seconds
+    let interval: NodeJS.Timeout | null = null;
+    if (autoRefresh) {
+      interval = setInterval(fetchLocations, 30000);
+    }
+
+    return () => {
+      if (interval) clearInterval(interval);
+    };
+  }, [fetchLocations, autoRefresh]);
+
+  const handleWardClick = useCallback((wardId: string) => {
+    setSelectedWardId(wardId);
+  }, []);
+
+  const selectedLocation = selectedWardId
+    ? locations.find((loc) => loc.wardId === selectedWardId)
+    : null;
+
+  const statusCounts = locations.reduce(
+    (acc, loc) => {
+      acc[loc.status] = (acc[loc.status] || 0) + 1;
+      return acc;
+    },
+    { normal: 0, warning: 0, emergency: 0 } as Record<string, number>
+  );
+
+  return (
+    <div style={{ display: "flex", height: "100vh", fontFamily: "sans-serif" }}>
+      {/* Sidebar */}
+      <aside
+        style={{
+          width: "320px",
+          backgroundColor: "#f9fafb",
+          borderRight: "1px solid #e5e7eb",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            padding: "16px",
+            borderBottom: "1px solid #e5e7eb",
+            backgroundColor: "white",
+          }}
+        >
+          <h1 style={{ margin: 0, fontSize: "18px", fontWeight: "bold" }}>
+            실시간 위치 현황
+          </h1>
+          <p style={{ margin: "8px 0 0", fontSize: "14px", color: "#6b7280" }}>
+            등록된 피보호자: {locations.length}명
+          </p>
+        </div>
+
+        {/* Status Summary */}
+        <div
+          style={{
+            display: "flex",
+            gap: "8px",
+            padding: "12px 16px",
+            borderBottom: "1px solid #e5e7eb",
+          }}
+        >
+          <StatusBadge
+            label="정상"
+            count={statusCounts.normal}
+            color="#22c55e"
+          />
+          <StatusBadge
+            label="주의"
+            count={statusCounts.warning}
+            color="#f59e0b"
+          />
+          <StatusBadge
+            label="비상"
+            count={statusCounts.emergency}
+            color="#ef4444"
+          />
+        </div>
+
+        {/* Controls */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "12px 16px",
+            borderBottom: "1px solid #e5e7eb",
+          }}
+        >
+          <label style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            <input
+              type="checkbox"
+              checked={autoRefresh}
+              onChange={(e) => setAutoRefresh(e.target.checked)}
+            />
+            <span style={{ fontSize: "14px" }}>자동 새로고침 (30초)</span>
+          </label>
+          <button
+            onClick={fetchLocations}
+            style={{
+              padding: "6px 12px",
+              fontSize: "13px",
+              backgroundColor: "#3b82f6",
+              color: "white",
+              border: "none",
+              borderRadius: "6px",
+              cursor: "pointer",
+            }}
+          >
+            새로고침
+          </button>
+        </div>
+
+        {/* Ward List */}
+        <div style={{ flex: 1, overflow: "auto" }}>
+          {isLoading ? (
+            <div style={{ padding: "24px", textAlign: "center", color: "#6b7280" }}>
+              로딩 중...
+            </div>
+          ) : error ? (
+            <div style={{ padding: "24px", textAlign: "center", color: "#ef4444" }}>
+              오류: {error}
+            </div>
+          ) : locations.length === 0 ? (
+            <div style={{ padding: "24px", textAlign: "center", color: "#6b7280" }}>
+              등록된 위치 정보가 없습니다.
+            </div>
+          ) : (
+            locations.map((loc) => (
+              <WardListItem
+                key={loc.wardId}
+                location={loc}
+                isSelected={loc.wardId === selectedWardId}
+                onClick={() => handleWardClick(loc.wardId)}
+              />
+            ))
+          )}
+        </div>
+
+        {/* Selected Ward Detail */}
+        {selectedLocation && (
+          <div
+            style={{
+              padding: "16px",
+              borderTop: "1px solid #e5e7eb",
+              backgroundColor: "white",
+            }}
+          >
+            <h3 style={{ margin: "0 0 12px", fontSize: "16px" }}>
+              {selectedLocation.wardName}
+            </h3>
+            <div style={{ fontSize: "13px", color: "#6b7280", lineHeight: "1.8" }}>
+              <div>
+                <strong>위치:</strong> {selectedLocation.latitude.toFixed(6)},{" "}
+                {selectedLocation.longitude.toFixed(6)}
+              </div>
+              {selectedLocation.accuracy && (
+                <div>
+                  <strong>정확도:</strong> {selectedLocation.accuracy.toFixed(1)}m
+                </div>
+              )}
+              <div>
+                <strong>마지막 업데이트:</strong>{" "}
+                {new Date(selectedLocation.lastUpdated).toLocaleString("ko-KR")}
+              </div>
+            </div>
+          </div>
+        )}
+      </aside>
+
+      {/* Map */}
+      <main style={{ flex: 1, position: "relative" }}>
+        <LocationMap
+          locations={locations}
+          onWardClick={handleWardClick}
+          selectedWardId={selectedWardId || undefined}
+        />
+      </main>
+    </div>
+  );
+}
+
+function StatusBadge({
+  label,
+  count,
+  color,
+}: {
+  label: string;
+  count: number;
+  color: string;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "4px",
+        padding: "4px 10px",
+        backgroundColor: color + "20",
+        borderRadius: "16px",
+      }}
+    >
+      <div
+        style={{
+          width: "8px",
+          height: "8px",
+          borderRadius: "50%",
+          backgroundColor: color,
+        }}
+      />
+      <span style={{ fontSize: "13px", color: "#374151" }}>
+        {label}: {count}
+      </span>
+    </div>
+  );
+}
+
+function WardListItem({
+  location,
+  isSelected,
+  onClick,
+}: {
+  location: WardLocation;
+  isSelected: boolean;
+  onClick: () => void;
+}) {
+  const statusColors: Record<string, string> = {
+    normal: "#22c55e",
+    warning: "#f59e0b",
+    emergency: "#ef4444",
+  };
+
+  const timeAgo = getTimeAgo(new Date(location.lastUpdated));
+
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        width: "100%",
+        display: "flex",
+        alignItems: "center",
+        gap: "12px",
+        padding: "12px 16px",
+        border: "none",
+        borderBottom: "1px solid #e5e7eb",
+        backgroundColor: isSelected ? "#eff6ff" : "transparent",
+        cursor: "pointer",
+        textAlign: "left",
+      }}
+    >
+      <div
+        style={{
+          width: "40px",
+          height: "40px",
+          borderRadius: "50%",
+          backgroundColor: statusColors[location.status],
+          color: "white",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontWeight: "bold",
+          fontSize: "14px",
+          flexShrink: 0,
+        }}
+      >
+        {location.wardName.charAt(0)}
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontWeight: isSelected ? "bold" : "normal",
+            fontSize: "14px",
+            marginBottom: "2px",
+          }}
+        >
+          {location.wardName}
+        </div>
+        <div style={{ fontSize: "12px", color: "#6b7280" }}>{timeAgo}</div>
+      </div>
+      <div
+        style={{
+          width: "8px",
+          height: "8px",
+          borderRadius: "50%",
+          backgroundColor: statusColors[location.status],
+          flexShrink: 0,
+        }}
+      />
+    </button>
+  );
+}
+
+function getTimeAgo(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+
+  if (diffSec < 60) return "방금 전";
+  if (diffMin < 60) return `${diffMin}분 전`;
+  if (diffHour < 24) return `${diffHour}시간 전`;
+  if (diffDay < 7) return `${diffDay}일 전`;
+  return date.toLocaleDateString("ko-KR");
+}

--- a/web/components/LocationMap.tsx
+++ b/web/components/LocationMap.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+declare global {
+  interface Window {
+    naver: typeof naver;
+  }
+}
+
+declare namespace naver {
+  namespace maps {
+    class Map {
+      constructor(element: HTMLElement, options: MapOptions);
+      setCenter(latlng: LatLng): void;
+      setZoom(level: number): void;
+      getCenter(): LatLng;
+      panTo(latlng: LatLng, options?: object): void;
+    }
+
+    class LatLng {
+      constructor(lat: number, lng: number);
+      lat(): number;
+      lng(): number;
+    }
+
+    class Marker {
+      constructor(options: MarkerOptions);
+      setMap(map: Map | null): void;
+      setPosition(latlng: LatLng): void;
+      setIcon(icon: ImageIcon): void;
+      getPosition(): LatLng;
+    }
+
+    class InfoWindow {
+      constructor(options: InfoWindowOptions);
+      open(map: Map, marker: Marker): void;
+      close(): void;
+      setContent(content: string): void;
+    }
+
+    interface MapOptions {
+      center: LatLng;
+      zoom: number;
+      minZoom?: number;
+      maxZoom?: number;
+    }
+
+    interface MarkerOptions {
+      position: LatLng;
+      map?: Map;
+      icon?: ImageIcon;
+      title?: string;
+    }
+
+    interface ImageIcon {
+      url?: string;
+      size?: Size;
+      scaledSize?: Size;
+      anchor?: Point;
+      content?: string;
+    }
+
+    interface InfoWindowOptions {
+      content: string;
+      maxWidth?: number;
+      backgroundColor?: string;
+      borderColor?: string;
+      borderWidth?: number;
+      anchorSize?: Size;
+      anchorSkew?: boolean;
+    }
+
+    class Size {
+      constructor(width: number, height: number);
+    }
+
+    class Point {
+      constructor(x: number, y: number);
+    }
+
+    namespace Event {
+      function addListener(
+        target: object,
+        eventName: string,
+        handler: (...args: unknown[]) => void
+      ): void;
+    }
+  }
+}
+
+export type WardLocation = {
+  wardId: string;
+  wardName: string;
+  latitude: number;
+  longitude: number;
+  accuracy: number | null;
+  lastUpdated: string;
+  status: "normal" | "warning" | "emergency";
+  organizationId: string | null;
+};
+
+type Props = {
+  locations: WardLocation[];
+  onWardClick?: (wardId: string) => void;
+  selectedWardId?: string;
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  normal: "#22c55e",
+  warning: "#f59e0b",
+  emergency: "#ef4444",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  normal: "정상",
+  warning: "주의",
+  emergency: "비상",
+};
+
+export function LocationMap({ locations, onWardClick, selectedWardId }: Props) {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<naver.maps.Map | null>(null);
+  const markersRef = useRef<Map<string, naver.maps.Marker>>(new Map());
+  const infoWindowRef = useRef<naver.maps.InfoWindow | null>(null);
+  const [isMapReady, setIsMapReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Initialize map
+  useEffect(() => {
+    const initMap = () => {
+      if (!mapRef.current || !window.naver?.maps) return;
+
+      const defaultCenter = new window.naver.maps.LatLng(37.5665, 126.978);
+      const map = new window.naver.maps.Map(mapRef.current, {
+        center: defaultCenter,
+        zoom: 12,
+        minZoom: 7,
+        maxZoom: 19,
+      });
+
+      mapInstanceRef.current = map;
+      infoWindowRef.current = new window.naver.maps.InfoWindow({
+        content: "",
+        maxWidth: 300,
+        backgroundColor: "#fff",
+        borderColor: "#ddd",
+        borderWidth: 1,
+        anchorSkew: true,
+      });
+
+      setIsMapReady(true);
+    };
+
+    // Check if Naver Maps is already loaded
+    if (window.naver?.maps) {
+      initMap();
+      return;
+    }
+
+    // Load Naver Maps script
+    const clientId = process.env.NEXT_PUBLIC_NAVER_MAP_CLIENT_ID;
+    if (!clientId) {
+      setError("Naver Map API 키가 설정되지 않았습니다.");
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = `https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=${clientId}`;
+    script.async = true;
+    script.onload = () => initMap();
+    script.onerror = () => setError("Naver Map 스크립트 로드 실패");
+    document.head.appendChild(script);
+
+    return () => {
+      // Cleanup markers
+      markersRef.current.forEach((marker) => marker.setMap(null));
+      markersRef.current.clear();
+    };
+  }, []);
+
+  // Update markers when locations change
+  useEffect(() => {
+    if (!isMapReady || !mapInstanceRef.current) return;
+
+    const map = mapInstanceRef.current;
+    const currentMarkerIds = new Set(markersRef.current.keys());
+    const newLocationIds = new Set(locations.map((loc) => loc.wardId));
+
+    // Remove markers that are no longer in locations
+    currentMarkerIds.forEach((id) => {
+      if (!newLocationIds.has(id)) {
+        const marker = markersRef.current.get(id);
+        if (marker) {
+          marker.setMap(null);
+          markersRef.current.delete(id);
+        }
+      }
+    });
+
+    // Add or update markers
+    locations.forEach((loc) => {
+      const position = new window.naver.maps.LatLng(loc.latitude, loc.longitude);
+      const existingMarker = markersRef.current.get(loc.wardId);
+
+      const iconContent = `
+        <div style="
+          width: 32px;
+          height: 32px;
+          background-color: ${STATUS_COLORS[loc.status]};
+          border: 2px solid white;
+          border-radius: 50%;
+          box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          color: white;
+          font-weight: bold;
+          font-size: 12px;
+        ">
+          ${loc.wardName.charAt(0)}
+        </div>
+      `;
+
+      if (existingMarker) {
+        existingMarker.setPosition(position);
+        existingMarker.setIcon({ content: iconContent });
+      } else {
+        const marker = new window.naver.maps.Marker({
+          position,
+          map,
+          icon: { content: iconContent },
+        });
+
+        window.naver.maps.Event.addListener(marker, "click", () => {
+          const infoContent = `
+            <div style="padding: 12px; min-width: 150px;">
+              <div style="font-weight: bold; font-size: 14px; margin-bottom: 8px;">
+                ${loc.wardName}
+              </div>
+              <div style="font-size: 12px; color: #666; margin-bottom: 4px;">
+                상태: <span style="color: ${STATUS_COLORS[loc.status]}; font-weight: bold;">
+                  ${STATUS_LABELS[loc.status]}
+                </span>
+              </div>
+              <div style="font-size: 12px; color: #666;">
+                마지막 업데이트: ${new Date(loc.lastUpdated).toLocaleString("ko-KR")}
+              </div>
+            </div>
+          `;
+
+          if (infoWindowRef.current) {
+            infoWindowRef.current.setContent(infoContent);
+            infoWindowRef.current.open(map, marker);
+          }
+
+          onWardClick?.(loc.wardId);
+        });
+
+        markersRef.current.set(loc.wardId, marker);
+      }
+    });
+
+    // Center map on first load if there are locations
+    if (locations.length > 0 && markersRef.current.size === locations.length) {
+      const bounds = locations.reduce(
+        (acc, loc) => ({
+          minLat: Math.min(acc.minLat, loc.latitude),
+          maxLat: Math.max(acc.maxLat, loc.latitude),
+          minLng: Math.min(acc.minLng, loc.longitude),
+          maxLng: Math.max(acc.maxLng, loc.longitude),
+        }),
+        { minLat: 90, maxLat: -90, minLng: 180, maxLng: -180 }
+      );
+
+      const centerLat = (bounds.minLat + bounds.maxLat) / 2;
+      const centerLng = (bounds.minLng + bounds.maxLng) / 2;
+      map.setCenter(new window.naver.maps.LatLng(centerLat, centerLng));
+    }
+  }, [isMapReady, locations, onWardClick]);
+
+  // Pan to selected ward
+  useEffect(() => {
+    if (!isMapReady || !mapInstanceRef.current || !selectedWardId) return;
+
+    const location = locations.find((loc) => loc.wardId === selectedWardId);
+    if (location) {
+      mapInstanceRef.current.panTo(
+        new window.naver.maps.LatLng(location.latitude, location.longitude),
+        { duration: 300 }
+      );
+    }
+  }, [isMapReady, selectedWardId, locations]);
+
+  if (error) {
+    return (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#f3f4f6",
+          color: "#ef4444",
+        }}
+      >
+        {error}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={mapRef}
+      style={{
+        width: "100%",
+        height: "100%",
+        minHeight: "400px",
+        backgroundColor: "#e5e7eb",
+      }}
+    >
+      {!isMapReady && (
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          지도 로딩 중...
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 피보호자 실시간 위치정보 저장 및 관제페이지에서 Naver Map으로 표시
- ward_locations (위치 이력) / ward_current_locations (최신 위치) 테이블 추가
- 위치 API 엔드포인트 구현
- Naver Map 통합 관제 UI 페이지 추가

## API Endpoints

### POST /v1/locations (모바일 -> 서버)
위치정보 업데이트 (Ward 사용자 전용)
```json
{
  "latitude": 37.5665,
  "longitude": 126.9780,
  "accuracy": 10.5,
  "timestamp": "2024-12-24T14:30:00Z"
}
```

### GET /v1/admin/locations (관제페이지)
모든 피보호자 실시간 위치 조회
- Query: organizationId (선택)

### GET /v1/admin/locations/:wardId/history
특정 피보호자 위치 이력 조회
- Query: from, to, limit

### PUT /v1/admin/locations/:wardId/status
피보호자 상태 변경 (normal/warning/emergency)

## Web UI
- `/locations` 페이지: 실시간 위치 현황 대시보드
- LocationMap 컴포넌트: Naver Maps API 연동
- 상태별 마커 아이콘 (정상/주의/비상)
- 자동 새로고침 (30초)
- 피보호자 목록 및 선택 시 지도 이동

## DB Schema
```sql
-- 위치 이력
ward_locations (ward_id, latitude, longitude, accuracy, recorded_at)

-- 최신 위치 (빠른 조회용)
ward_current_locations (ward_id, latitude, longitude, status, last_updated)
```

## Dependencies
- Naver Maps API (환경변수: NEXT_PUBLIC_NAVER_MAP_CLIENT_ID)

Closes #15