### PR TITLE
feat(web): 관제센터 UI 및 인증 개선 (#42)

### DIFF
--- a/api/src/app.service.spec.ts
+++ b/api/src/app.service.spec.ts
@@ -117,7 +117,6 @@ const mockPushService = {
 
 const mockAuthService = {
   verifyAccessToken: jest.fn(),
-  verifyTempToken: jest.fn(),
   kakaoLogin: jest.fn(),
   refreshTokens: jest.fn(),
   registerGuardian: jest.fn(),
@@ -259,10 +258,10 @@ describe('Issue #4: 보호자 회원가입 API', () => {
     expect(mockAuthService.registerGuardian).toBeDefined();
   });
 
-  it('임시 토큰 + 어르신 정보로 가입해야 함', async () => {
+  it('Access Token + 어르신 정보로 가입 완료해야 함', async () => {
     mockAuthService.registerGuardian.mockResolvedValue({
-      accessToken: 'access_token',
-      refreshToken: 'refresh_token',
+      accessToken: 'new_access_token',
+      refreshToken: 'new_refresh_token',
       user: { id: 'user-1', userType: 'guardian' },
       guardianInfo: {
         id: 'guardian-1',
@@ -272,7 +271,7 @@ describe('Issue #4: 보호자 회원가입 API', () => {
     });
 
     const result = await mockAuthService.registerGuardian({
-      tempToken: 'temp_token',
+      accessToken: 'access_token', // 카카오 로그인 시 발급받은 액세스 토큰
       wardEmail: 'ward@email.com',
       wardPhoneNumber: '010-1234-5678',
     });

--- a/api/src/db.service.ts
+++ b/api/src/db.service.ts
@@ -416,6 +416,13 @@ export class DbService implements OnModuleInit, OnModuleDestroy {
     return result.rows[0];
   }
 
+  async updateUserType(userId: string, userType: 'guardian' | 'ward') {
+    await this.pool.query(
+      `update users set user_type = $1, updated_at = now() where id = $2`,
+      [userType, userId],
+    );
+  }
+
   async findGuardianByWardEmail(wardEmail: string) {
     const result = await this.pool.query<GuardianRow>(
       `select id, user_id, ward_email, ward_phone_number, created_at, updated_at
@@ -432,7 +439,7 @@ export class DbService implements OnModuleInit, OnModuleDestroy {
     email: string | null;
     nickname: string | null;
     profileImageUrl: string | null;
-    userType: 'guardian' | 'ward';
+    userType: 'guardian' | 'ward' | null;
   }) {
     const identity = `kakao_${params.kakaoId}`;
     const result = await this.pool.query<UserRow>(

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -105,9 +105,23 @@ export default function DashboardPage() {
 
   const fetchStats = useCallback(async () => {
     try {
+      const token = localStorage.getItem("admin_access_token");
+      if (!token) {
+        window.location.href = "/login";
+        return;
+      }
       console.log("[Dashboard] Fetching stats from:", `${API_BASE}/v1/admin/dashboard/stats`);
-      const response = await fetch(`${API_BASE}/v1/admin/dashboard/stats`);
+      const response = await fetch(`${API_BASE}/v1/admin/dashboard/stats`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
       if (!response.ok) {
+        if (response.status === 401) {
+          localStorage.removeItem("admin_access_token");
+          localStorage.removeItem("admin_refresh_token");
+          localStorage.removeItem("admin_info");
+          window.location.href = "/login";
+          return;
+        }
         const errorText = await response.text();
         console.error("[Dashboard] Stats fetch failed:", response.status, errorText);
         throw new Error(`HTTP ${response.status}: ${errorText}`);
@@ -126,8 +140,24 @@ export default function DashboardPage() {
 
   const fetchRealtime = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE}/v1/admin/dashboard/realtime`);
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const token = localStorage.getItem("admin_access_token");
+      if (!token) {
+        window.location.href = "/login";
+        return;
+      }
+      const response = await fetch(`${API_BASE}/v1/admin/dashboard/realtime`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!response.ok) {
+        if (response.status === 401) {
+          localStorage.removeItem("admin_access_token");
+          localStorage.removeItem("admin_refresh_token");
+          localStorage.removeItem("admin_info");
+          window.location.href = "/login";
+          return;
+        }
+        throw new Error(`HTTP ${response.status}`);
+      }
       const data = await response.json();
       setRealtime(data);
     } catch {

--- a/web/app/locations/page.tsx
+++ b/web/app/locations/page.tsx
@@ -15,8 +15,22 @@ export default function LocationsPage() {
 
   const fetchLocations = useCallback(async () => {
     try {
-      const response = await fetch(`${API_BASE}/v1/admin/locations`);
+      const token = localStorage.getItem("admin_access_token");
+      if (!token) {
+        window.location.href = "/login";
+        return;
+      }
+      const response = await fetch(`${API_BASE}/v1/admin/locations`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
       if (!response.ok) {
+        if (response.status === 401) {
+          localStorage.removeItem("admin_access_token");
+          localStorage.removeItem("admin_refresh_token");
+          localStorage.removeItem("admin_info");
+          window.location.href = "/login";
+          return;
+        }
         throw new Error(`HTTP ${response.status}`);
       }
       const data = await response.json();

--- a/web/app/my-wards/page.tsx
+++ b/web/app/my-wards/page.tsx
@@ -75,7 +75,11 @@ export default function MyWardsPage() {
 
       if (!response.ok) {
         if (response.status === 401) {
-          setError("로그인이 만료되었습니다");
+          // 토큰 만료 - 자동 로그아웃
+          localStorage.removeItem("admin_access_token");
+          localStorage.removeItem("admin_refresh_token");
+          localStorage.removeItem("admin_info");
+          window.location.href = "/login";
           return;
         }
         throw new Error(`HTTP ${response.status}`);

--- a/web/app/page.module.css
+++ b/web/app/page.module.css
@@ -2,105 +2,10 @@
   display: flex;
   flex-direction: column;
   gap: 0;
-  height: calc(100vh - 80px);
+  height: 100%;
+  min-height: 0;
   overflow: hidden;
   background: var(--bg);
-}
-
-.gridHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px 24px;
-  background: white;
-  border-bottom: 1px solid #e2e8f0;
-  border-radius: 12px 12px 0 0;
-  flex-shrink: 0;
-}
-
-.gridInfo {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.gridLabel {
-  font-size: 14px;
-  font-weight: 500;
-  color: #64748b;
-}
-
-.gridValue {
-  font-size: 16px;
-  font-weight: 700;
-  color: #1e293b;
-  padding: 6px 14px;
-  background: #f1f5f9;
-  border-radius: 8px;
-}
-
-.gridControl {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.gridBtn {
-  width: 36px;
-  height: 36px;
-  border-radius: 10px;
-  border: 1px solid #e2e8f0;
-  background: white;
-  color: #1e293b;
-  font-size: 18px;
-  font-weight: 600;
-  cursor: pointer;
-  display: grid;
-  place-items: center;
-  transition: all 150ms ease;
-}
-
-.gridBtn:hover:not(:disabled) {
-  background: #f1f5f9;
-  border-color: #3b82f6;
-  color: #3b82f6;
-}
-
-.gridBtn:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-.gridSlider {
-  width: 120px;
-  height: 6px;
-  -webkit-appearance: none;
-  appearance: none;
-  background: #e2e8f0;
-  border-radius: 4px;
-  outline: none;
-}
-
-.gridSlider::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background: #3b82f6;
-  cursor: pointer;
-  border: 3px solid white;
-  box-shadow: 0 2px 6px rgba(59, 130, 246, 0.4);
-}
-
-.gridSlider::-moz-range-thumb {
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background: #3b82f6;
-  cursor: pointer;
-  border: 3px solid white;
-  box-shadow: 0 2px 6px rgba(59, 130, 246, 0.4);
 }
 
 .roomWrap {
@@ -123,6 +28,10 @@
   grid-template-columns: minmax(0, 1fr) 320px;
   min-height: 0;
   height: 100%;
+}
+
+.contentFullWidth {
+  grid-template-columns: 1fr;
 }
 
 .stage {
@@ -621,7 +530,7 @@
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
   flex-shrink: 0;
   position: fixed;
-  left: calc(240px + 50%);
+  left: 50%;
   transform: translateX(-50%);
   bottom: calc(20px + env(safe-area-inset-bottom));
   z-index: 10;
@@ -720,6 +629,51 @@
   cursor: not-allowed;
 }
 
+.gridSpinner {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  background: #f1f5f9;
+  border-radius: 10px;
+}
+
+.gridSpinnerBtn {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: none;
+  background: white;
+  display: grid;
+  place-items: center;
+  color: #475569;
+  cursor: pointer;
+  transition: all 150ms ease;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
+
+.gridSpinnerBtn:hover:not(:disabled) {
+  background: #3b82f6;
+  color: white;
+}
+
+.gridSpinnerBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.gridSpinnerValue {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1e293b;
+  min-width: 60px;
+  justify-content: center;
+}
+
 .joinBanner {
   position: absolute;
   top: 16px;
@@ -773,6 +727,10 @@
     grid-template-columns: 1fr;
   }
 
+  .contentFullWidth {
+    grid-template-columns: 1fr;
+  }
+
   .sidebar {
     border-left: none;
     border-top: 1px solid #e2e8f0;
@@ -785,23 +743,7 @@
 
 @media (max-width: 768px) {
   .page {
-    height: calc(100vh - 60px);
-  }
-
-  .gridHeader {
-    padding: 12px 16px;
-    flex-direction: column;
-    gap: 12px;
-    align-items: flex-start;
-  }
-
-  .gridControl {
-    width: 100%;
-    justify-content: space-between;
-  }
-
-  .gridSlider {
-    flex: 1;
+    height: 100%;
   }
 
   .stage {

--- a/web/app/select-organization/page.tsx
+++ b/web/app/select-organization/page.tsx
@@ -61,6 +61,13 @@ export default function SelectOrganizationPage() {
       });
 
       if (!response.ok) {
+        if (response.status === 401) {
+          localStorage.removeItem("admin_access_token");
+          localStorage.removeItem("admin_refresh_token");
+          localStorage.removeItem("admin_info");
+          window.location.href = "/login";
+          return;
+        }
         const data = await response.json();
         throw new Error(data.message || "조직 생성에 실패했습니다.");
       }
@@ -78,6 +85,13 @@ export default function SelectOrganizationPage() {
       });
 
       if (!updateResponse.ok) {
+        if (updateResponse.status === 401) {
+          localStorage.removeItem("admin_access_token");
+          localStorage.removeItem("admin_refresh_token");
+          localStorage.removeItem("admin_info");
+          window.location.href = "/login";
+          return;
+        }
         const data = await updateResponse.json();
         throw new Error(data.message || "조직 선택에 실패했습니다.");
       }

--- a/web/components/SidebarLayout.tsx
+++ b/web/components/SidebarLayout.tsx
@@ -1,9 +1,22 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { ReactNode } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { ReactNode, useState } from "react";
 import AuthGuard from "./AuthGuard";
+import { useSessionMonitor } from "../hooks/useSessionMonitor";
+
+const IconMenu = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+    <path d="M3 12h18M3 6h18M3 18h18" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+  </svg>
+);
+
+const IconClose = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+    <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+  </svg>
+);
 
 const IconMonitor = () => (
   <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
@@ -70,78 +83,133 @@ const navItems = [
 type SidebarLayoutProps = {
   children: ReactNode;
   title?: string;
+  noPadding?: boolean;
 };
 
-export default function SidebarLayout({ children, title }: SidebarLayoutProps) {
+export default function SidebarLayout({ children, title, noPadding }: SidebarLayoutProps) {
   const pathname = usePathname();
+  const router = useRouter();
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
-  const handleLogout = () => {
-    localStorage.removeItem("admin_access_token");
-    localStorage.removeItem("admin_refresh_token");
-    localStorage.removeItem("admin_info");
-    window.location.href = "/login";
-  };
+  // 세션 모니터링 (토큰 만료 시점에 정확히 발동, 5분 전 경고)
+  const { handleLogout } = useSessionMonitor({
+    warningBeforeExpiryMs: 5 * 60 * 1000,
+  });
 
   return (
     <AuthGuard>
-      <div
+      {/* Toggle Button (when collapsed) */}
+      {sidebarCollapsed && (
+        <button
+          onClick={() => {
+            console.log("[DEBUG] Menu button clicked - opening sidebar");
+            setSidebarCollapsed(false);
+          }}
+          style={{
+            position: "fixed",
+            top: "16px",
+            left: "8px",
+            width: "44px",
+            height: "44px",
+            borderRadius: "12px",
+            border: "1px solid #e2e8f0",
+            background: "white",
+            display: "grid",
+            placeItems: "center",
+            color: "#475569",
+            cursor: "pointer",
+            boxShadow: "0 2px 8px rgba(0,0,0,0.08)",
+            zIndex: 9999,
+          }}
+        >
+          <IconMenu />
+        </button>
+      )}
+
+      {/* Sidebar */}
+      <aside
         style={{
-          display: "flex",
-          minHeight: "100vh",
-          backgroundColor: "#f8fafc",
-        }}
-      >
-        {/* Fixed Sidebar */}
-        <aside
-        style={{
+          position: "fixed",
+          top: 0,
+          left: 0,
+          bottom: 0,
           width: "240px",
           backgroundColor: "#ffffff",
           borderRight: "1px solid #e2e8f0",
           display: "flex",
           flexDirection: "column",
-          position: "fixed",
-          top: 0,
-          left: 0,
-          bottom: 0,
-          zIndex: 50,
+          transform: sidebarCollapsed ? "translateX(-240px)" : "translateX(0)",
+          transition: "transform 200ms ease",
+          zIndex: 9999,
         }}
       >
-        {/* Logo */}
-        <div
-          style={{
-            padding: "20px 16px",
-            borderBottom: "1px solid #e2e8f0",
-          }}
-        >
-          <Link
-            href="/"
+          {/* Logo */}
+          <div
             style={{
+              padding: "20px 16px",
+              borderBottom: "1px solid #e2e8f0",
               display: "flex",
               alignItems: "center",
-              gap: "12px",
-              textDecoration: "none",
+              justifyContent: "space-between",
             }}
           >
-            <div
+            <Link
+              href="/"
               style={{
-                width: "36px",
-                height: "36px",
-                borderRadius: "10px",
-                background: "conic-gradient(from 120deg, #3b82f6, #1e40af, #22c55e, #3b82f6)",
-                boxShadow: "0 0 0 3px rgba(59, 130, 246, 0.12)",
-              }}
-            />
-            <span
-              style={{
-                fontSize: "18px",
-                fontWeight: 700,
-                color: "#1e293b",
+                display: "flex",
+                alignItems: "center",
+                gap: "12px",
+                textDecoration: "none",
               }}
             >
-              담소 관제센터
-            </span>
-          </Link>
-        </div>
+              <div
+                style={{
+                  width: "36px",
+                  height: "36px",
+                  borderRadius: "10px",
+                  background: "conic-gradient(from 120deg, #3b82f6, #1e40af, #22c55e, #3b82f6)",
+                  boxShadow: "0 0 0 3px rgba(59, 130, 246, 0.12)",
+                }}
+              />
+              <span
+                style={{
+                  fontSize: "18px",
+                  fontWeight: 700,
+                  color: "#1e293b",
+                }}
+              >
+                담소 관제센터
+              </span>
+            </Link>
+            <button
+              onClick={() => {
+                console.log("[DEBUG] Close button clicked - collapsing sidebar");
+                setSidebarCollapsed(true);
+              }}
+              style={{
+                width: "32px",
+                height: "32px",
+                borderRadius: "8px",
+                border: "none",
+                background: "transparent",
+                display: "grid",
+                placeItems: "center",
+                color: "#94a3b8",
+                cursor: "pointer",
+                transition: "all 150ms ease",
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.backgroundColor = "#f1f5f9";
+                e.currentTarget.style.color = "#64748b";
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.backgroundColor = "transparent";
+                e.currentTarget.style.color = "#94a3b8";
+              }}
+            >
+              <IconClose />
+            </button>
+          </div>
 
         {/* Navigation */}
         <nav
@@ -157,21 +225,29 @@ export default function SidebarLayout({ children, title }: SidebarLayoutProps) {
             const isActive = pathname === item.href;
             const Icon = item.icon;
             return (
-              <Link
+              <button
                 key={item.href}
-                href={item.href}
+                type="button"
+                onClick={() => {
+                  console.log("[DEBUG] Nav button clicked, navigating to:", item.href);
+                  window.location.href = item.href;
+                }}
                 style={{
                   display: "flex",
                   alignItems: "center",
                   gap: "12px",
                   padding: "12px 14px",
                   borderRadius: "10px",
+                  border: "none",
                   textDecoration: "none",
                   fontSize: "14px",
                   fontWeight: isActive ? 600 : 500,
                   color: isActive ? "#3b82f6" : "#475569",
                   backgroundColor: isActive ? "rgba(59, 130, 246, 0.08)" : "transparent",
                   transition: "all 150ms ease",
+                  cursor: "pointer",
+                  width: "100%",
+                  textAlign: "left",
                 }}
                 onMouseEnter={(e) => {
                   if (!isActive) {
@@ -188,7 +264,7 @@ export default function SidebarLayout({ children, title }: SidebarLayoutProps) {
               >
                 <Icon />
                 <span>{item.label}</span>
-              </Link>
+              </button>
             );
           })}
         </nav>
@@ -236,8 +312,12 @@ export default function SidebarLayout({ children, title }: SidebarLayoutProps) {
       <main
         style={{
           flex: 1,
-          marginLeft: "240px",
+          marginLeft: sidebarCollapsed ? 0 : "240px",
           minHeight: "100vh",
+          height: noPadding ? "100vh" : undefined,
+          display: noPadding ? "flex" : undefined,
+          flexDirection: noPadding ? "column" : undefined,
+          transition: "margin-left 200ms ease",
         }}
       >
         {/* Header */}
@@ -266,9 +346,8 @@ export default function SidebarLayout({ children, title }: SidebarLayoutProps) {
         )}
 
         {/* Page Content */}
-        <div style={{ padding: "24px 28px" }}>{children}</div>
+        <div style={noPadding ? { flex: 1, minHeight: 0, display: "flex", flexDirection: "column" } : { padding: "24px 28px" }}>{children}</div>
       </main>
-      </div>
     </AuthGuard>
   );
 }

--- a/web/hooks/useSessionMonitor.ts
+++ b/web/hooks/useSessionMonitor.ts
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useCallback, useRef } from "react";
+
+type SessionMonitorOptions = {
+  warningBeforeExpiryMs?: number; // 만료 전 경고 시간 (기본: 5분)
+  onExpired?: () => void; // 만료 시 콜백
+  onWarning?: (remainingMs: number) => void; // 만료 임박 시 콜백
+};
+
+// JWT 토큰에서 payload 추출
+function parseJwt(token: string): { exp?: number; iat?: number } | null {
+  try {
+    const base64Url = token.split(".")[1];
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+    const jsonPayload = decodeURIComponent(
+      atob(base64)
+        .split("")
+        .map((c) => "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2))
+        .join("")
+    );
+    return JSON.parse(jsonPayload);
+  } catch {
+    return null;
+  }
+}
+
+// 토큰 만료 시간 가져오기 (ms)
+function getTokenExpiry(token: string): number | null {
+  const payload = parseJwt(token);
+  if (payload?.exp) {
+    return payload.exp * 1000; // seconds to ms
+  }
+  return null;
+}
+
+export function useSessionMonitor(options: SessionMonitorOptions = {}) {
+  const {
+    warningBeforeExpiryMs = 5 * 60 * 1000, // 5분 전 경고
+    onExpired,
+    onWarning,
+  } = options;
+
+  const expiryTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const warningTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const mountedRef = useRef(true);
+
+  const handleLogout = useCallback(() => {
+    localStorage.removeItem("admin_access_token");
+    localStorage.removeItem("admin_refresh_token");
+    localStorage.removeItem("admin_info");
+    window.location.href = "/login";
+  }, []);
+
+  const clearTimers = useCallback(() => {
+    if (expiryTimerRef.current) {
+      clearTimeout(expiryTimerRef.current);
+      expiryTimerRef.current = null;
+    }
+    if (warningTimerRef.current) {
+      clearTimeout(warningTimerRef.current);
+      warningTimerRef.current = null;
+    }
+  }, []);
+
+  const setupTimers = useCallback(() => {
+    clearTimers();
+
+    const token = localStorage.getItem("admin_access_token");
+    if (!token) {
+      // 토큰 없으면 바로 로그인으로
+      handleLogout();
+      return;
+    }
+
+    const expiry = getTokenExpiry(token);
+    if (!expiry) {
+      // 토큰 파싱 실패
+      handleLogout();
+      return;
+    }
+
+    const now = Date.now();
+    const remainingMs = expiry - now;
+
+    console.log(`[SessionMonitor] Token expires in ${Math.round(remainingMs / 1000)}s`);
+
+    if (remainingMs <= 0) {
+      // 이미 만료됨
+      if (onExpired) {
+        onExpired();
+      } else {
+        alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+        handleLogout();
+      }
+      return;
+    }
+
+    // 만료 타이머 설정 (정확히 만료 시점에 발동)
+    expiryTimerRef.current = setTimeout(() => {
+      if (!mountedRef.current) return;
+      console.log("[SessionMonitor] Session expired!");
+      if (onExpired) {
+        onExpired();
+      } else {
+        alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+        handleLogout();
+      }
+    }, remainingMs);
+
+    // 경고 타이머 설정 (만료 N분 전)
+    const warningTime = remainingMs - warningBeforeExpiryMs;
+    if (warningTime > 0) {
+      warningTimerRef.current = setTimeout(() => {
+        if (!mountedRef.current) return;
+        const timeLeft = warningBeforeExpiryMs;
+        console.log(`[SessionMonitor] Warning: ${Math.round(timeLeft / 60000)}min left`);
+        if (onWarning) {
+          onWarning(timeLeft);
+        } else {
+          const minutes = Math.ceil(timeLeft / 60000);
+          const shouldLogout = confirm(
+            `세션이 ${minutes}분 후 만료됩니다.\n\n계속 사용하시려면 '취소'를 누르세요.\n지금 로그아웃하시려면 '확인'을 누르세요.`
+          );
+          if (shouldLogout) {
+            handleLogout();
+          }
+        }
+      }, warningTime);
+    }
+  }, [clearTimers, handleLogout, onExpired, onWarning, warningBeforeExpiryMs]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    // 초기 타이머 설정
+    setupTimers();
+
+    // 탭 활성화 시 타이머 재설정 (다른 탭에서 로그아웃했을 수 있음)
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        setupTimers();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    // storage 이벤트 (다른 탭에서 토큰 변경 감지)
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === "admin_access_token") {
+        if (!e.newValue) {
+          // 다른 탭에서 로그아웃함
+          handleLogout();
+        } else {
+          // 토큰 갱신됨 - 타이머 재설정
+          setupTimers();
+        }
+      }
+    };
+    window.addEventListener("storage", handleStorageChange);
+
+    return () => {
+      mountedRef.current = false;
+      clearTimers();
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("storage", handleStorageChange);
+    };
+  }, [setupTimers, clearTimers, handleLogout]);
+
+  return { handleLogout, refreshTimers: setupTimers };
+}


### PR DESCRIPTION
## Summary
- 그리드 컨트롤을 헤더에서 하단 컨트롤 바로 이동 (공간 효율성 개선)
- 참여자 목록 토글 기능 추가 (목록 숨기기/보이기)
- 한글 랜덤 이름 생성 로직 제거 → 카카오 nickname 사용
- 각 관제 페이지(dashboard, emergencies, locations, my-wards)에 토큰 검증 추가
- 401 응답 시 자동 로그아웃 및 로그인 페이지 리다이렉트 처리
- SidebarLayout에 noPadding 옵션 추가
- db.service에 updateUserType() 함수 추가
- 테스트 코드 tempToken → accessToken 업데이트

## Test plan
- [ ] 관제 페이지 접근 시 토큰 없으면 로그인 페이지로 리다이렉트 확인
- [ ] 토큰 만료 시 자동 로그아웃 및 리다이렉트 확인
- [ ] 그리드 크기 조절 (3x3 ~ 7x7) 동작 확인
- [ ] 참여자 목록 토글 버튼 동작 확인
- [ ] SidebarLayout noPadding 옵션 적용 확인

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)