### PR TITLE
refactor(api): Phase 1 - 공통 모듈 및 기반 구조 설정 (#44)

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -2,15 +2,24 @@ import { Module } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { AuthService } from './auth.service';
-import { DbService } from './db.service';
 import { PushService } from './push.service';
 import { NotificationScheduler } from './notification.scheduler';
 import { AiService } from './ai.service';
+import { CommonModule } from './common/common.module';
+import { DatabaseModule } from './database/database.module';
 
 @Module({
-  imports: [ScheduleModule.forRoot()],
+  imports: [
+    ScheduleModule.forRoot(),
+    CommonModule,
+    DatabaseModule,
+  ],
   controllers: [AppController],
-  providers: [AppService, AuthService, DbService, PushService, NotificationScheduler, AiService],
+  providers: [
+    AppService,
+    PushService,
+    NotificationScheduler,
+    AiService,
+  ],
 })
 export class AppModule {}

--- a/api/src/common/common.module.ts
+++ b/api/src/common/common.module.ts
@@ -1,0 +1,29 @@
+import { Module, Global } from '@nestjs/common';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { AdminAuthGuard } from './guards/admin-auth.guard';
+import { AuthService } from '../auth.service';
+import { DbService } from '../db.service';
+
+/**
+ * 공통 모듈
+ * Guards, Decorators, Filters 등 공통 유틸리티 제공
+ *
+ * @Global() 데코레이터로 전역 모듈로 등록
+ * - JwtAuthGuard, AdminAuthGuard를 다른 모듈에서 주입받아 사용 가능
+ */
+@Global()
+@Module({
+  providers: [
+    JwtAuthGuard,
+    AdminAuthGuard,
+    AuthService,
+    DbService,
+  ],
+  exports: [
+    JwtAuthGuard,
+    AdminAuthGuard,
+    AuthService,
+    DbService,
+  ],
+})
+export class CommonModule {}

--- a/api/src/common/decorators/current-user.decorator.ts
+++ b/api/src/common/decorators/current-user.decorator.ts
@@ -1,0 +1,50 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export type CurrentUserPayload = {
+  sub: string;
+  type: 'access' | 'refresh';
+  userType?: 'guardian' | 'ward';
+};
+
+export type CurrentAdminPayload = {
+  sub: string;
+  email: string;
+  role: string;
+  type: string;
+};
+
+/**
+ * 현재 인증된 사용자 정보를 추출하는 데코레이터
+ * JwtAuthGuard와 함께 사용
+ *
+ * @example
+ * @UseGuards(JwtAuthGuard)
+ * @Get('/me')
+ * getMe(@CurrentUser() user: CurrentUserPayload) {
+ *   return this.usersService.findById(user.sub);
+ * }
+ */
+export const CurrentUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): CurrentUserPayload => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);
+
+/**
+ * 현재 인증된 관리자 정보를 추출하는 데코레이터
+ * AdminAuthGuard와 함께 사용
+ *
+ * @example
+ * @UseGuards(AdminAuthGuard)
+ * @Get('/admin/dashboard')
+ * getDashboard(@CurrentAdmin() admin: CurrentAdminPayload) {
+ *   return this.dashboardService.getStats(admin.sub);
+ * }
+ */
+export const CurrentAdmin = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): CurrentAdminPayload => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.admin;
+  },
+);

--- a/api/src/common/filters/http-exception.filter.ts
+++ b/api/src/common/filters/http-exception.filter.ts
@@ -1,0 +1,57 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { Response } from 'express';
+
+/**
+ * 전역 HTTP 예외 필터
+ * 모든 HttpException을 일관된 형식으로 응답
+ *
+ * @example
+ * // main.ts에서 전역 등록
+ * app.useGlobalFilters(new HttpExceptionFilter());
+ */
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(HttpExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest();
+
+    const status =
+      exception instanceof HttpException
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    const message =
+      exception instanceof HttpException
+        ? exception.message
+        : 'Internal server error';
+
+    const errorResponse = {
+      statusCode: status,
+      message,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+    };
+
+    // 5xx 에러는 상세 로깅
+    if (status >= 500) {
+      this.logger.error(
+        `${request.method} ${request.url} ${status}`,
+        exception instanceof Error ? exception.stack : undefined,
+      );
+    } else if (status >= 400) {
+      this.logger.warn(`${request.method} ${request.url} ${status} - ${message}`);
+    }
+
+    response.status(status).json(errorResponse);
+  }
+}

--- a/api/src/common/guards/admin-auth.guard.ts
+++ b/api/src/common/guards/admin-auth.guard.ts
@@ -1,0 +1,41 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { AuthService } from '../../auth.service';
+
+/**
+ * 관리자 JWT 인증 Guard
+ * Authorization: Bearer <adminAccessToken> 헤더 검증
+ *
+ * @example
+ * @UseGuards(AdminAuthGuard)
+ * @Get('/v1/admin/dashboard/stats')
+ * getStats(@CurrentAdmin() admin: CurrentAdminPayload) { ... }
+ */
+@Injectable()
+export class AdminAuthGuard implements CanActivate {
+  constructor(private readonly authService: AuthService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const authorization = request.headers.authorization;
+
+    if (!authorization?.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Missing or invalid authorization header');
+    }
+
+    const token = authorization.slice(7);
+
+    try {
+      const payload = this.authService.verifyAdminAccessToken(token);
+      // request.admin에 payload 저장 (CurrentAdmin 데코레이터에서 사용)
+      request.admin = payload;
+      return true;
+    } catch {
+      throw new UnauthorizedException('Invalid or expired admin access token');
+    }
+  }
+}

--- a/api/src/common/guards/jwt-auth.guard.ts
+++ b/api/src/common/guards/jwt-auth.guard.ts
@@ -1,0 +1,41 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { AuthService } from '../../auth.service';
+
+/**
+ * 일반 사용자 JWT 인증 Guard
+ * Authorization: Bearer <accessToken> 헤더 검증
+ *
+ * @example
+ * @UseGuards(JwtAuthGuard)
+ * @Get('/v1/users/me')
+ * getMe(@CurrentUser() user: CurrentUserPayload) { ... }
+ */
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  constructor(private readonly authService: AuthService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const authorization = request.headers.authorization;
+
+    if (!authorization?.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Missing or invalid authorization header');
+    }
+
+    const token = authorization.slice(7);
+    const payload = this.authService.verifyAccessToken(token);
+
+    if (!payload) {
+      throw new UnauthorizedException('Invalid or expired access token');
+    }
+
+    // request.user에 payload 저장 (CurrentUser 데코레이터에서 사용)
+    request.user = payload;
+    return true;
+  }
+}

--- a/api/src/common/index.ts
+++ b/api/src/common/index.ts
@@ -1,0 +1,13 @@
+// Decorators
+export { CurrentUser, CurrentAdmin } from './decorators/current-user.decorator';
+export type {
+  CurrentUserPayload,
+  CurrentAdminPayload,
+} from './decorators/current-user.decorator';
+
+// Guards
+export { JwtAuthGuard } from './guards/jwt-auth.guard';
+export { AdminAuthGuard } from './guards/admin-auth.guard';
+
+// Filters
+export { HttpExceptionFilter } from './filters/http-exception.filter';

--- a/api/src/database/database.module.ts
+++ b/api/src/database/database.module.ts
@@ -1,0 +1,22 @@
+import { Module, Global } from '@nestjs/common';
+import { DbService } from '../db.service';
+
+/**
+ * 데이터베이스 모듈
+ *
+ * 현재는 DbService를 제공하며, 향후 Phase에서 다음과 같이 분리 예정:
+ * - UsersRepository
+ * - GuardiansRepository
+ * - WardsRepository
+ * - CallsRepository
+ * - DevicesRepository
+ * - 등등...
+ *
+ * @Global() 데코레이터로 전역 모듈로 등록
+ */
+@Global()
+@Module({
+  providers: [DbService],
+  exports: [DbService],
+})
+export class DatabaseModule {}

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -1,0 +1,2 @@
+export { DatabaseModule } from './database.module';
+export { DbService } from '../db.service';


### PR DESCRIPTION
## Summary
- 모듈 기반 아키텍처 리팩토링의 첫 번째 단계
- `common/` 디렉토리 생성: Guards, Decorators, Filters 공통 유틸리티
- `database/` 디렉토리 생성: DB 모듈 분리 준비
- `app.module.ts`에 CommonModule, DatabaseModule 등록

## 변경 내용

### common/
| 파일 | 설명 |
|------|------|
| `decorators/current-user.decorator.ts` | @CurrentUser, @CurrentAdmin 데코레이터 |
| `guards/jwt-auth.guard.ts` | 일반 사용자 JWT 인증 Guard |
| `guards/admin-auth.guard.ts` | 관리자 JWT 인증 Guard |
| `filters/http-exception.filter.ts` | 전역 HTTP 예외 필터 |
| `common.module.ts` | @Global 공통 모듈 |

### database/
| 파일 | 설명 |
|------|------|
| `database.module.ts` | @Global DB 모듈 (향후 Repository 분리 준비) |

## Test plan
- [x] Docker 빌드 성공 확인
- [ ] 서비스 실행 테스트

## 다음 단계
- Phase 2: 인증/사용자 모듈 분리 (auth/, users/)
- Phase 3: 핵심 도메인 모듈 분리 (guardians/, wards/, calls/)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)