### PR TITLE
refactor(api): Phase 3 - 핵심 도메인 모듈 분리 (#48)

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -9,6 +9,9 @@ import { CommonModule } from './common/common.module';
 import { DatabaseModule } from './database/database.module';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
+import { GuardiansModule } from './guardians/guardians.module';
+import { WardsModule } from './wards/wards.module';
+import { CallsModule } from './calls/calls.module';
 
 @Module({
   imports: [
@@ -17,6 +20,9 @@ import { UsersModule } from './users/users.module';
     DatabaseModule,
     AuthModule,
     UsersModule,
+    GuardiansModule,
+    WardsModule,
+    CallsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/api/src/calls/calls.controller.ts
+++ b/api/src/calls/calls.controller.ts
@@ -1,0 +1,137 @@
+import {
+  Controller,
+  Post,
+  Body,
+  Param,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { AppService } from '../app.service';
+import { AiService } from '../ai.service';
+import { NotificationScheduler } from '../notification.scheduler';
+
+@Controller('v1/calls')
+export class CallsController {
+  private readonly logger = new Logger(CallsController.name);
+
+  constructor(
+    private readonly appService: AppService,
+    private readonly aiService: AiService,
+    private readonly notificationScheduler: NotificationScheduler,
+  ) {}
+
+  @Post('invite')
+  async invite(
+    @Headers('authorization') authorization: string | undefined,
+    @Body() body: {
+      callerIdentity?: string;
+      callerName?: string;
+      calleeIdentity?: string;
+      roomName?: string;
+    },
+  ) {
+    const config = this.appService.getConfig();
+    const auth = this.appService.getAuthContext(authorization);
+    if (config.authRequired && !auth) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    const callerIdentity = body.callerIdentity?.trim() || auth?.identity;
+    if (!callerIdentity) {
+      throw new HttpException('callerIdentity is required', HttpStatus.BAD_REQUEST);
+    }
+    const calleeIdentity = body.calleeIdentity?.trim();
+    if (!calleeIdentity) {
+      throw new HttpException('calleeIdentity is required', HttpStatus.BAD_REQUEST);
+    }
+
+    this.logger.log(
+      `invite caller=${callerIdentity} callee=${calleeIdentity} room=${body.roomName ?? 'auto'}`,
+    );
+    return await this.appService.inviteCall({
+      callerIdentity,
+      callerName: body.callerName?.trim(),
+      calleeIdentity,
+      roomName: body.roomName?.trim(),
+    });
+  }
+
+  @Post('answer')
+  async answer(
+    @Headers('authorization') authorization: string | undefined,
+    @Body() body: { callId?: string },
+  ) {
+    const config = this.appService.getConfig();
+    const auth = this.appService.getAuthContext(authorization);
+    if (config.authRequired && !auth) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    const callId = body.callId?.trim();
+    if (!callId) {
+      throw new HttpException('callId is required', HttpStatus.BAD_REQUEST);
+    }
+
+    this.logger.log(`answer callId=${callId}`);
+    return await this.appService.answerCall(callId);
+  }
+
+  @Post('end')
+  async end(
+    @Headers('authorization') authorization: string | undefined,
+    @Body() body: { callId?: string },
+  ) {
+    const config = this.appService.getConfig();
+    const auth = this.appService.getAuthContext(authorization);
+    if (config.authRequired && !auth) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    const callId = body.callId?.trim();
+    if (!callId) {
+      throw new HttpException('callId is required', HttpStatus.BAD_REQUEST);
+    }
+
+    this.logger.log(`end callId=${callId}`);
+    const result = await this.appService.endCall(callId);
+
+    // 비동기로 보호자에게 통화 완료 알림 전송
+    this.notificationScheduler.notifyCallComplete(callId).catch((error) => {
+      this.logger.warn(`end notifyCallComplete failed callId=${callId} error=${(error as Error).message}`);
+    });
+
+    return result;
+  }
+
+  @Post(':callId/analyze')
+  async analyze(
+    @Headers('authorization') authorization: string | undefined,
+    @Param('callId') callId: string,
+  ) {
+    const config = this.appService.getConfig();
+    const auth = this.appService.getAuthContext(authorization);
+    if (config.authRequired && !auth) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    if (!callId?.trim()) {
+      throw new HttpException('callId is required', HttpStatus.BAD_REQUEST);
+    }
+
+    this.logger.log(`analyze callId=${callId}`);
+
+    try {
+      const result = await this.aiService.analyzeCall(callId);
+      return result;
+    } catch (error) {
+      const message = (error as Error).message;
+      if (message.includes('not found')) {
+        throw new HttpException('Call not found', HttpStatus.NOT_FOUND);
+      }
+      this.logger.error(`analyze failed callId=${callId} error=${message}`);
+      throw new HttpException('Failed to analyze call', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/api/src/calls/calls.module.ts
+++ b/api/src/calls/calls.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { CallsController } from './calls.controller';
+import { AppService } from '../app.service';
+import { AiService } from '../ai.service';
+import { NotificationScheduler } from '../notification.scheduler';
+import { DbService } from '../db.service';
+import { PushService } from '../push.service';
+
+@Module({
+  controllers: [CallsController],
+  providers: [AppService, AiService, NotificationScheduler, DbService, PushService],
+})
+export class CallsModule {}

--- a/api/src/calls/index.ts
+++ b/api/src/calls/index.ts
@@ -1,0 +1,2 @@
+export { CallsModule } from './calls.module';
+export { CallsController } from './calls.controller';

--- a/api/src/guardians/guardians.controller.ts
+++ b/api/src/guardians/guardians.controller.ts
@@ -1,0 +1,181 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  Query,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { GuardiansService } from './guardians.service';
+import { AuthService } from '../auth/auth.service';
+
+@Controller('v1/guardian')
+export class GuardiansController {
+  private readonly logger = new Logger(GuardiansController.name);
+
+  constructor(
+    private readonly guardiansService: GuardiansService,
+    private readonly authService: AuthService,
+  ) {}
+
+  private verifyAuthHeader(authorization: string | undefined) {
+    const authHeader = authorization ?? '';
+    const token = authHeader.startsWith('Bearer ')
+      ? authHeader.slice('Bearer '.length).trim()
+      : undefined;
+
+    if (!token) {
+      throw new HttpException('Access token is required', HttpStatus.UNAUTHORIZED);
+    }
+
+    const payload = this.authService.verifyAccessToken(token);
+    if (!payload) {
+      throw new HttpException('Invalid or expired access token', HttpStatus.UNAUTHORIZED);
+    }
+
+    return payload;
+  }
+
+  @Get('dashboard')
+  async getDashboard(@Headers('authorization') authorization: string | undefined) {
+    const payload = this.verifyAuthHeader(authorization);
+
+    try {
+      return await this.guardiansService.getDashboard(payload.sub);
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(`getDashboard failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to get dashboard', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Get('report')
+  async getReport(
+    @Headers('authorization') authorization: string | undefined,
+    @Query('period') period?: string,
+  ) {
+    const payload = this.verifyAuthHeader(authorization);
+    const reportPeriod = period === 'month' ? 'month' : 'week';
+
+    try {
+      return await this.guardiansService.getReport(payload.sub, reportPeriod);
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(`getReport failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to get report', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Get('wards')
+  async getWards(@Headers('authorization') authorization: string | undefined) {
+    const payload = this.verifyAuthHeader(authorization);
+
+    try {
+      return await this.guardiansService.getWards(payload.sub);
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(`getWards failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to get wards', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Post('wards')
+  async addWard(
+    @Headers('authorization') authorization: string | undefined,
+    @Body() body: { wardEmail?: string; wardPhoneNumber?: string },
+  ) {
+    const payload = this.verifyAuthHeader(authorization);
+
+    const wardEmail = body.wardEmail?.trim();
+    const wardPhoneNumber = body.wardPhoneNumber?.trim();
+
+    if (!wardEmail) {
+      throw new HttpException('wardEmail is required', HttpStatus.BAD_REQUEST);
+    }
+    if (!wardPhoneNumber) {
+      throw new HttpException('wardPhoneNumber is required', HttpStatus.BAD_REQUEST);
+    }
+    if (!wardEmail.includes('@')) {
+      throw new HttpException('Invalid email format', HttpStatus.BAD_REQUEST);
+    }
+    if (!/^[\d-]+$/.test(wardPhoneNumber)) {
+      throw new HttpException('Invalid phone number format', HttpStatus.BAD_REQUEST);
+    }
+
+    try {
+      return await this.guardiansService.addWard(payload.sub, wardEmail, wardPhoneNumber);
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(`addWard failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to add ward', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Put('wards/:wardId')
+  async updateWard(
+    @Headers('authorization') authorization: string | undefined,
+    @Param('wardId') wardId: string,
+    @Body() body: { wardEmail?: string; wardPhoneNumber?: string },
+  ) {
+    const payload = this.verifyAuthHeader(authorization);
+
+    const wardEmail = body.wardEmail?.trim();
+    const wardPhoneNumber = body.wardPhoneNumber?.trim();
+
+    if (!wardEmail) {
+      throw new HttpException('wardEmail is required', HttpStatus.BAD_REQUEST);
+    }
+    if (!wardPhoneNumber) {
+      throw new HttpException('wardPhoneNumber is required', HttpStatus.BAD_REQUEST);
+    }
+    if (!wardEmail.includes('@')) {
+      throw new HttpException('Invalid email format', HttpStatus.BAD_REQUEST);
+    }
+    if (!/^[\d-]+$/.test(wardPhoneNumber)) {
+      throw new HttpException('Invalid phone number format', HttpStatus.BAD_REQUEST);
+    }
+
+    try {
+      return await this.guardiansService.updateWard(payload.sub, wardId, wardEmail, wardPhoneNumber);
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(`updateWard failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to update ward', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Delete('wards/:wardId')
+  async deleteWard(
+    @Headers('authorization') authorization: string | undefined,
+    @Param('wardId') wardId: string,
+  ) {
+    const payload = this.verifyAuthHeader(authorization);
+
+    try {
+      await this.guardiansService.deleteWard(payload.sub, wardId);
+      return { success: true, message: '피보호자 등록이 삭제되었습니다.' };
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(`deleteWard failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to delete ward', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/api/src/guardians/guardians.module.ts
+++ b/api/src/guardians/guardians.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { GuardiansController } from './guardians.controller';
+import { GuardiansService } from './guardians.service';
+import { AuthService } from '../auth/auth.service';
+import { DbService } from '../db.service';
+
+@Module({
+  controllers: [GuardiansController],
+  providers: [GuardiansService, AuthService, DbService],
+  exports: [GuardiansService],
+})
+export class GuardiansModule {}

--- a/api/src/guardians/guardians.service.ts
+++ b/api/src/guardians/guardians.service.ts
@@ -1,0 +1,202 @@
+import { Injectable, HttpException, HttpStatus, Logger } from '@nestjs/common';
+import { DbService } from '../db.service';
+
+@Injectable()
+export class GuardiansService {
+  private readonly logger = new Logger(GuardiansService.name);
+
+  constructor(private readonly dbService: DbService) {}
+
+  async verifyGuardianAccess(userId: string) {
+    const user = await this.dbService.findUserById(userId);
+    if (!user || user.user_type !== 'guardian') {
+      throw new HttpException('Guardian access required', HttpStatus.FORBIDDEN);
+    }
+
+    const guardian = await this.dbService.findGuardianByUserId(user.id);
+    if (!guardian) {
+      throw new HttpException('Guardian info not found', HttpStatus.NOT_FOUND);
+    }
+
+    return { user, guardian };
+  }
+
+  async getDashboard(userId: string) {
+    const { guardian } = await this.verifyGuardianAccess(userId);
+    const linkedWard = await this.dbService.findWardByGuardianId(guardian.id);
+
+    if (!linkedWard) {
+      return {
+        statistics: {
+          totalCalls: 0,
+          weeklyChange: 0,
+          averageDuration: 0,
+          overallMood: { positive: 0, negative: 0 },
+        },
+        alerts: [],
+        recentCalls: [],
+      };
+    }
+
+    this.logger.log(`getDashboard guardianId=${guardian.id} wardId=${linkedWard.id}`);
+
+    const [stats, weeklyChange, moodStats, alerts, recentCalls] = await Promise.all([
+      this.dbService.getWardCallStats(linkedWard.id),
+      this.dbService.getWardWeeklyCallChange(linkedWard.id),
+      this.dbService.getWardMoodStats(linkedWard.id),
+      this.dbService.getHealthAlerts(guardian.id, 5),
+      this.dbService.getRecentCallSummaries(linkedWard.id, 5),
+    ]);
+
+    return {
+      statistics: {
+        totalCalls: stats.totalCalls,
+        weeklyChange,
+        averageDuration: stats.avgDuration,
+        overallMood: moodStats,
+      },
+      alerts,
+      recentCalls,
+    };
+  }
+
+  async getReport(userId: string, period: 'week' | 'month') {
+    const { guardian } = await this.verifyGuardianAccess(userId);
+    const days = period === 'month' ? 30 : 7;
+    const linkedWard = await this.dbService.findWardByGuardianId(guardian.id);
+
+    if (!linkedWard) {
+      return {
+        period,
+        emotionTrend: [],
+        healthKeywords: {},
+        topTopics: [],
+        weeklySummary: '연결된 어르신이 없습니다.',
+        recommendations: [],
+      };
+    }
+
+    this.logger.log(`getReport guardianId=${guardian.id} wardId=${linkedWard.id} period=${period}`);
+
+    const [emotionTrend, healthKeywords, topTopics, summaries] = await Promise.all([
+      this.dbService.getEmotionTrend(linkedWard.id, days),
+      this.dbService.getHealthKeywordStats(linkedWard.id, days),
+      this.dbService.getTopTopics(linkedWard.id, days, 5),
+      this.dbService.getCallSummariesForReport(linkedWard.id, days),
+    ]);
+
+    const summaryTexts = summaries
+      .filter((s) => s.summary)
+      .map((s) => s.summary)
+      .slice(0, 3);
+    const weeklySummary = summaryTexts.length > 0
+      ? `최근 ${days}일간 ${summaries.length}건의 대화가 있었습니다. ${summaryTexts.join(' ')}`
+      : `최근 ${days}일간 대화 기록이 없습니다.`;
+
+    const recommendations: string[] = [];
+    if (healthKeywords.pain.count > 0) {
+      recommendations.push('통증 관련 언급이 있었습니다. 건강 상태를 확인해보세요.');
+    }
+    if (emotionTrend.some((e) => e.mood === 'negative')) {
+      recommendations.push('부정적인 감정이 감지되었습니다. 대화를 나눠보세요.');
+    }
+    if (summaries.length < 3) {
+      recommendations.push('대화 빈도가 적습니다. 정기적인 통화를 권장합니다.');
+    }
+
+    return {
+      period,
+      emotionTrend,
+      healthKeywords,
+      topTopics,
+      weeklySummary,
+      recommendations,
+    };
+  }
+
+  async getWards(userId: string) {
+    const { guardian } = await this.verifyGuardianAccess(userId);
+    this.logger.log(`getWards guardianId=${guardian.id}`);
+
+    const wards = await this.dbService.getGuardianWards(guardian.id);
+
+    return {
+      wards: wards.map((w) => ({
+        id: w.id,
+        email: w.ward_email,
+        phoneNumber: w.ward_phone_number,
+        isPrimary: w.is_primary,
+        nickname: w.ward_nickname,
+        profileImageUrl: w.ward_profile_image_url,
+        isLinked: w.linked_ward_id !== null,
+        lastCallAt: w.last_call_at,
+      })),
+    };
+  }
+
+  async addWard(userId: string, wardEmail: string, wardPhoneNumber: string) {
+    const { guardian } = await this.verifyGuardianAccess(userId);
+    this.logger.log(`addWard guardianId=${guardian.id} wardEmail=${wardEmail}`);
+
+    const registration = await this.dbService.createGuardianWardRegistration({
+      guardianId: guardian.id,
+      wardEmail,
+      wardPhoneNumber,
+    });
+
+    return {
+      id: registration.id,
+      wardEmail: registration.ward_email,
+      wardPhoneNumber: registration.ward_phone_number,
+      isLinked: false,
+    };
+  }
+
+  async updateWard(userId: string, wardId: string, wardEmail: string, wardPhoneNumber: string) {
+    const { guardian } = await this.verifyGuardianAccess(userId);
+
+    const registration = await this.dbService.findGuardianWardRegistration(wardId, guardian.id);
+    if (!registration) {
+      throw new HttpException('Ward registration not found', HttpStatus.NOT_FOUND);
+    }
+
+    this.logger.log(`updateWard registrationId=${wardId}`);
+    const updated = await this.dbService.updateGuardianWardRegistration({
+      id: wardId,
+      guardianId: guardian.id,
+      wardEmail,
+      wardPhoneNumber,
+    });
+
+    return {
+      id: updated.id,
+      wardEmail: updated.ward_email,
+      wardPhoneNumber: updated.ward_phone_number,
+      linkedWard: updated.linked_ward_id
+        ? {
+            id: updated.linked_ward_id,
+            nickname: null,
+            profileImageUrl: null,
+          }
+        : null,
+      updatedAt: updated.updated_at,
+    };
+  }
+
+  async deleteWard(userId: string, wardId: string) {
+    const { guardian } = await this.verifyGuardianAccess(userId);
+
+    // Primary ward인 경우 연결만 해제
+    if (wardId === guardian.id) {
+      await this.dbService.unlinkPrimaryWard(guardian.id);
+      return;
+    }
+
+    // 추가 등록 삭제 (deleteGuardianWardRegistration 내부에서 ward 연결 해제 처리)
+    this.logger.log(`deleteWard registrationId=${wardId}`);
+    const deleted = await this.dbService.deleteGuardianWardRegistration(wardId, guardian.id);
+    if (!deleted) {
+      throw new HttpException('Ward registration not found', HttpStatus.NOT_FOUND);
+    }
+  }
+}

--- a/api/src/guardians/index.ts
+++ b/api/src/guardians/index.ts
@@ -1,0 +1,3 @@
+export { GuardiansModule } from './guardians.module';
+export { GuardiansController } from './guardians.controller';
+export { GuardiansService } from './guardians.service';

--- a/api/src/wards/index.ts
+++ b/api/src/wards/index.ts
@@ -1,0 +1,3 @@
+export { WardsModule } from './wards.module';
+export { WardsController } from './wards.controller';
+export { WardsService } from './wards.service';

--- a/api/src/wards/wards.controller.ts
+++ b/api/src/wards/wards.controller.ts
@@ -1,0 +1,81 @@
+import {
+  Controller,
+  Get,
+  Put,
+  Body,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { WardsService } from './wards.service';
+import { AuthService } from '../auth/auth.service';
+
+@Controller('v1/ward')
+export class WardsController {
+  private readonly logger = new Logger(WardsController.name);
+
+  constructor(
+    private readonly wardsService: WardsService,
+    private readonly authService: AuthService,
+  ) {}
+
+  private verifyAuthHeader(authorization: string | undefined) {
+    const authHeader = authorization ?? '';
+    const token = authHeader.startsWith('Bearer ')
+      ? authHeader.slice('Bearer '.length).trim()
+      : undefined;
+
+    if (!token) {
+      throw new HttpException('Access token is required', HttpStatus.UNAUTHORIZED);
+    }
+
+    const payload = this.authService.verifyAccessToken(token);
+    if (!payload) {
+      throw new HttpException('Invalid or expired access token', HttpStatus.UNAUTHORIZED);
+    }
+
+    return payload;
+  }
+
+  @Get('settings')
+  async getSettings(@Headers('authorization') authorization: string | undefined) {
+    const payload = this.verifyAuthHeader(authorization);
+
+    try {
+      return await this.wardsService.getSettings(payload.sub);
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(`getSettings failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to get ward settings', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Put('settings')
+  async updateSettings(
+    @Headers('authorization') authorization: string | undefined,
+    @Body() body: {
+      aiPersona?: string;
+      weeklyCallCount?: number;
+      callDurationMinutes?: number;
+    },
+  ) {
+    const payload = this.verifyAuthHeader(authorization);
+
+    try {
+      return await this.wardsService.updateSettings(payload.sub, {
+        aiPersona: body.aiPersona,
+        weeklyCallCount: body.weeklyCallCount,
+        callDurationMinutes: body.callDurationMinutes,
+      });
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(`updateSettings failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to update ward settings', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/api/src/wards/wards.module.ts
+++ b/api/src/wards/wards.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { WardsController } from './wards.controller';
+import { WardsService } from './wards.service';
+import { AuthService } from '../auth/auth.service';
+import { DbService } from '../db.service';
+
+@Module({
+  controllers: [WardsController],
+  providers: [WardsService, AuthService, DbService],
+  exports: [WardsService],
+})
+export class WardsModule {}

--- a/api/src/wards/wards.service.ts
+++ b/api/src/wards/wards.service.ts
@@ -1,0 +1,78 @@
+import { Injectable, HttpException, HttpStatus, Logger } from '@nestjs/common';
+import { DbService } from '../db.service';
+
+@Injectable()
+export class WardsService {
+  private readonly logger = new Logger(WardsService.name);
+
+  constructor(private readonly dbService: DbService) {}
+
+  async verifyWardAccess(userId: string) {
+    const user = await this.dbService.findUserById(userId);
+    if (!user || user.user_type !== 'ward') {
+      throw new HttpException('Ward access required', HttpStatus.FORBIDDEN);
+    }
+
+    const ward = await this.dbService.findWardByUserId(user.id);
+    if (!ward) {
+      throw new HttpException('Ward info not found', HttpStatus.NOT_FOUND);
+    }
+
+    return { user, ward };
+  }
+
+  async getSettings(userId: string) {
+    const { user, ward } = await this.verifyWardAccess(userId);
+    this.logger.log(`getSettings userId=${user.id} wardId=${ward.id}`);
+
+    const notificationSettings = await this.dbService.getNotificationSettings(user.id);
+
+    return {
+      aiPersona: ward.ai_persona,
+      weeklyCallCount: ward.weekly_call_count,
+      callDurationMinutes: ward.call_duration_minutes,
+      notificationSettings: {
+        callReminder: notificationSettings.call_reminder,
+        callComplete: notificationSettings.call_complete,
+        healthAlert: notificationSettings.health_alert,
+      },
+    };
+  }
+
+  async updateSettings(
+    userId: string,
+    settings: {
+      aiPersona?: string;
+      weeklyCallCount?: number;
+      callDurationMinutes?: number;
+    },
+  ) {
+    const { user, ward } = await this.verifyWardAccess(userId);
+
+    if (settings.weeklyCallCount !== undefined && (settings.weeklyCallCount < 1 || settings.weeklyCallCount > 7)) {
+      throw new HttpException('weeklyCallCount must be between 1 and 7', HttpStatus.BAD_REQUEST);
+    }
+    if (settings.callDurationMinutes !== undefined && (settings.callDurationMinutes < 5 || settings.callDurationMinutes > 60)) {
+      throw new HttpException('callDurationMinutes must be between 5 and 60', HttpStatus.BAD_REQUEST);
+    }
+
+    this.logger.log(`updateSettings userId=${user.id} wardId=${ward.id}`);
+
+    const updated = await this.dbService.updateWardSettings({
+      wardId: user.id,
+      aiPersona: settings.aiPersona?.trim(),
+      weeklyCallCount: settings.weeklyCallCount,
+      callDurationMinutes: settings.callDurationMinutes,
+    });
+
+    if (!updated) {
+      throw new HttpException('Failed to update settings', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    return {
+      aiPersona: updated.ai_persona,
+      weeklyCallCount: updated.weekly_call_count,
+      callDurationMinutes: updated.call_duration_minutes,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- guardians/ 모듈: 보호자 대시보드, 리포트, 피보호자 관리
- wards/ 모듈: 어르신 설정 관리
- calls/ 모듈: 통화 초대, 응답, 종료, AI 분석

## 변경 내용

| 모듈 | 엔드포인트 |
|------|----------|
| guardians | /v1/guardian/dashboard, report, wards (CRUD) |
| wards | /v1/ward/settings (GET/PUT) |
| calls | /v1/calls/invite, answer, end, :callId/analyze |

## Test plan
- [x] Docker 빌드 성공 확인

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)