### PR TITLE
refactor(api): 인프라 모듈 분리 (rtc, push, devices) (#50)

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -12,6 +12,9 @@ import { UsersModule } from './users/users.module';
 import { GuardiansModule } from './guardians/guardians.module';
 import { WardsModule } from './wards/wards.module';
 import { CallsModule } from './calls/calls.module';
+import { RtcModule } from './rtc/rtc.module';
+import { DevicesModule } from './devices/devices.module';
+import { PushModule } from './push/push.module';
 
 @Module({
   imports: [
@@ -23,6 +26,9 @@ import { CallsModule } from './calls/calls.module';
     GuardiansModule,
     WardsModule,
     CallsModule,
+    RtcModule,
+    DevicesModule,
+    PushModule,
   ],
   controllers: [AppController],
   providers: [

--- a/api/src/devices/devices.controller.ts
+++ b/api/src/devices/devices.controller.ts
@@ -1,0 +1,82 @@
+import {
+  Controller,
+  Post,
+  Body,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { AppService } from '../app.service';
+
+@Controller('v1/devices')
+export class DevicesController {
+  private readonly logger = new Logger(DevicesController.name);
+
+  constructor(private readonly appService: AppService) {}
+
+  private summarizeToken(token: string | undefined): string {
+    if (!token) return 'none';
+    const len = token.length;
+    if (len <= 8) return `${len}c`;
+    return `${token.slice(0, 4)}..${token.slice(-4)}`;
+  }
+
+  @Post('register')
+  async registerDevice(
+    @Headers('authorization') authorization: string | undefined,
+    @Body()
+    body: {
+      identity?: string;
+      displayName?: string;
+      platform?: string;
+      env?: 'prod' | 'sandbox';
+      apnsToken?: string;
+      voipToken?: string;
+      supportsCallKit?: boolean;
+    },
+  ) {
+    const config = this.appService.getConfig();
+    const auth = this.appService.getAuthContext(authorization);
+    if (config.authRequired && !auth) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    const identity = body.identity?.trim() || auth?.identity;
+    if (!identity) {
+      throw new HttpException('identity is required', HttpStatus.BAD_REQUEST);
+    }
+
+    const displayName = body.displayName?.trim() || auth?.displayName;
+    const platform = body.platform?.trim() || 'ios';
+    const env = body.env;
+    const supportsCallKit = body.supportsCallKit ?? true;
+
+    if (env && !['prod', 'sandbox'].includes(env)) {
+      throw new HttpException('invalid env', HttpStatus.BAD_REQUEST);
+    }
+
+    try {
+      this.logger.log(
+        `registerDevice identity=${identity} platform=${platform} env=${env ?? 'default'} supportsCallKit=${supportsCallKit} apns=${this.summarizeToken(body.apnsToken)} voip=${this.summarizeToken(body.voipToken)}`,
+      );
+      return await this.appService.registerDevice({
+        identity,
+        displayName,
+        platform,
+        env,
+        apnsToken: body.apnsToken,
+        voipToken: body.voipToken,
+        supportsCallKit,
+      });
+    } catch (error) {
+      this.logger.warn(
+        `registerDevice failed identity=${identity} error=${(error as Error).message}`,
+      );
+      throw new HttpException(
+        (error as Error).message || 'Bad request',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+}

--- a/api/src/devices/devices.module.ts
+++ b/api/src/devices/devices.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { DevicesController } from './devices.controller';
+import { AppService } from '../app.service';
+import { AuthService } from '../auth/auth.service';
+import { DbService } from '../db.service';
+import { PushService } from '../push.service';
+
+@Module({
+  controllers: [DevicesController],
+  providers: [AppService, AuthService, DbService, PushService],
+})
+export class DevicesModule {}

--- a/api/src/devices/index.ts
+++ b/api/src/devices/index.ts
@@ -1,0 +1,2 @@
+export { DevicesModule } from './devices.module';
+export { DevicesController } from './devices.controller';

--- a/api/src/push/index.ts
+++ b/api/src/push/index.ts
@@ -1,0 +1,2 @@
+export { PushModule } from './push.module';
+export { PushController } from './push.controller';

--- a/api/src/push/push.controller.ts
+++ b/api/src/push/push.controller.ts
@@ -1,0 +1,101 @@
+import {
+  Controller,
+  Post,
+  Body,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { AppService } from '../app.service';
+
+@Controller('v1/push')
+export class PushController {
+  private readonly logger = new Logger(PushController.name);
+
+  constructor(private readonly appService: AppService) {}
+
+  private summarizePayloadKeys(payload: Record<string, unknown> | undefined): string {
+    if (!payload) return 'none';
+    const keys = Object.keys(payload);
+    if (keys.length === 0) return 'empty';
+    return keys.join(',');
+  }
+
+  @Post('broadcast')
+  async pushBroadcast(
+    @Headers('authorization') authorization: string | undefined,
+    @Body()
+    body: {
+      type?: 'alert' | 'voip';
+      title?: string;
+      body?: string;
+      payload?: Record<string, unknown>;
+      env?: 'prod' | 'sandbox';
+    },
+  ) {
+    const config = this.appService.getConfig();
+    const auth = this.appService.getAuthContext(authorization);
+    if (config.authRequired && !auth) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    const type = body.type ?? 'alert';
+    if (!['alert', 'voip'].includes(type)) {
+      throw new HttpException('invalid type', HttpStatus.BAD_REQUEST);
+    }
+
+    this.logger.log(
+      `pushBroadcast type=${type} env=${body.env ?? 'default'} payloadKeys=${this.summarizePayloadKeys(body.payload)}`,
+    );
+    return await this.appService.sendBroadcastPush({
+      type,
+      title: body.title,
+      body: body.body,
+      payload: body.payload,
+      env: body.env,
+    });
+  }
+
+  @Post('user')
+  async pushUser(
+    @Headers('authorization') authorization: string | undefined,
+    @Body()
+    body: {
+      identity?: string;
+      type?: 'alert' | 'voip';
+      title?: string;
+      body?: string;
+      payload?: Record<string, unknown>;
+      env?: 'prod' | 'sandbox';
+    },
+  ) {
+    const config = this.appService.getConfig();
+    const auth = this.appService.getAuthContext(authorization);
+    if (config.authRequired && !auth) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    const identity = body.identity?.trim() || auth?.identity;
+    if (!identity) {
+      throw new HttpException('identity is required', HttpStatus.BAD_REQUEST);
+    }
+
+    const type = body.type ?? 'alert';
+    if (!['alert', 'voip'].includes(type)) {
+      throw new HttpException('invalid type', HttpStatus.BAD_REQUEST);
+    }
+
+    this.logger.log(
+      `pushUser identity=${identity} type=${type} env=${body.env ?? 'default'} payloadKeys=${this.summarizePayloadKeys(body.payload)}`,
+    );
+    return await this.appService.sendUserPush({
+      identity,
+      type,
+      title: body.title,
+      body: body.body,
+      payload: body.payload,
+      env: body.env,
+    });
+  }
+}

--- a/api/src/push/push.module.ts
+++ b/api/src/push/push.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PushController } from './push.controller';
+import { AppService } from '../app.service';
+import { AuthService } from '../auth/auth.service';
+import { DbService } from '../db.service';
+import { PushService } from '../push.service';
+
+@Module({
+  controllers: [PushController],
+  providers: [AppService, AuthService, DbService, PushService],
+})
+export class PushModule {}

--- a/api/src/rtc/index.ts
+++ b/api/src/rtc/index.ts
@@ -1,0 +1,2 @@
+export { RtcModule } from './rtc.module';
+export { RtcController } from './rtc.controller';

--- a/api/src/rtc/rtc.controller.ts
+++ b/api/src/rtc/rtc.controller.ts
@@ -1,0 +1,159 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { AppService } from '../app.service';
+import { AuthService } from '../auth/auth.service';
+import { DbService } from '../db.service';
+
+@Controller()
+export class RtcController {
+  private readonly logger = new Logger(RtcController.name);
+
+  constructor(
+    private readonly appService: AppService,
+    private readonly authService: AuthService,
+    private readonly dbService: DbService,
+  ) {}
+
+  private normalizeLivekitUrl(url: string | undefined): string | undefined {
+    if (!url) return undefined;
+    const trimmed = url.trim();
+    if (!trimmed.startsWith('wss://') && !trimmed.startsWith('ws://')) {
+      return undefined;
+    }
+    return trimmed.replace(/\/+$/, '');
+  }
+
+  private summarizeToken(token: string | undefined): string {
+    if (!token) return 'none';
+    const len = token.length;
+    if (len <= 8) return `${len}c`;
+    return `${token.slice(0, 4)}..${token.slice(-4)}`;
+  }
+
+  @Get('v1/rooms/:roomName/members')
+  async listMembers(
+    @Headers('authorization') authorization: string | undefined,
+    @Param('roomName') roomNameParam: string,
+  ) {
+    const config = this.appService.getConfig();
+    const auth = this.appService.getAuthContext(authorization);
+    if (config.authRequired && !auth) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    const roomName = roomNameParam?.trim();
+    if (!roomName) {
+      throw new HttpException('roomName is required', HttpStatus.BAD_REQUEST);
+    }
+
+    const members = await this.appService.listRoomMembers(roomName);
+    this.logger.log(`listMembers room=${roomName} count=${members.length}`);
+    return { roomName, members };
+  }
+
+  @Post('v1/rtc/token')
+  async issueToken(
+    @Headers('authorization') authorization: string | undefined,
+    @Body() body: {
+      roomName?: string;
+      identity?: string;
+      name?: string;
+      role?: 'host' | 'viewer' | 'observer';
+      livekitUrl?: string;
+      apnsToken?: string;
+      voipToken?: string;
+      platform?: string;
+      env?: 'prod' | 'sandbox';
+      supportsCallKit?: boolean;
+    },
+  ) {
+    const config = this.appService.getConfig();
+    const authHeader = authorization ?? '';
+    const bearer = authHeader.startsWith('Bearer ')
+      ? authHeader.slice('Bearer '.length)
+      : undefined;
+
+    let authIdentity: string | undefined;
+    let authName: string | undefined;
+
+    if (bearer) {
+      const kakaoPayload = this.authService.verifyAccessToken(bearer);
+      if (kakaoPayload) {
+        const user = await this.dbService.findUserById(kakaoPayload.sub);
+        if (user) {
+          authIdentity = user.identity;
+          authName = user.nickname ?? user.display_name ?? undefined;
+        }
+      } else {
+        try {
+          const payload = this.appService.verifyApiToken(bearer);
+          authIdentity = payload.identity;
+          authName = payload.displayName;
+        } catch {
+          if (config.authRequired) {
+            throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+          }
+        }
+      }
+    } else if (config.authRequired) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    const roomName = body.roomName?.trim();
+    if (!roomName) {
+      throw new HttpException('roomName is required', HttpStatus.BAD_REQUEST);
+    }
+
+    const identity = (body.identity ?? authIdentity)?.trim();
+    if (!identity) {
+      throw new HttpException('identity is required', HttpStatus.BAD_REQUEST);
+    }
+
+    const name = (authName ?? body.name ?? identity).trim();
+    const role = body.role ?? 'viewer';
+
+    if (!['host', 'viewer', 'observer'].includes(role)) {
+      throw new HttpException('invalid role', HttpStatus.BAD_REQUEST);
+    }
+
+    const livekitUrlOverride = this.normalizeLivekitUrl(body.livekitUrl);
+    if (body.livekitUrl && !livekitUrlOverride) {
+      throw new HttpException('invalid livekitUrl', HttpStatus.BAD_REQUEST);
+    }
+
+    this.logger.log(
+      `issueToken room=${roomName} identity=${identity} role=${role} env=${body.env ?? 'default'} livekit=${livekitUrlOverride ?? 'default'} apns=${this.summarizeToken(body.apnsToken)} voip=${this.summarizeToken(body.voipToken)}`,
+    );
+
+    const rtcData = await this.appService.issueRtcToken({
+      roomName,
+      identity,
+      name,
+      role,
+      device:
+        body.apnsToken || body.voipToken || body.platform || body.env || body.supportsCallKit !== undefined
+          ? {
+              apnsToken: body.apnsToken?.trim(),
+              voipToken: body.voipToken?.trim(),
+              platform: body.platform?.trim(),
+              env: body.env,
+              supportsCallKit: body.supportsCallKit,
+            }
+          : undefined,
+    });
+
+    return {
+      ...rtcData,
+      livekitUrl: livekitUrlOverride ?? rtcData.livekitUrl,
+    };
+  }
+}

--- a/api/src/rtc/rtc.module.ts
+++ b/api/src/rtc/rtc.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { RtcController } from './rtc.controller';
+import { AppService } from '../app.service';
+import { AuthService } from '../auth/auth.service';
+import { DbService } from '../db.service';
+import { PushService } from '../push.service';
+
+@Module({
+  controllers: [RtcController],
+  providers: [AppService, AuthService, DbService, PushService],
+})
+export class RtcModule {}


### PR DESCRIPTION
## Summary
- rtc/ 모듈 생성: RTC 토큰 발급(`POST /v1/rtc/token`), 방 멤버 조회(`GET /v1/rooms/:roomName/members`) 엔드포인트
- push/ 모듈 생성: 브로드캐스트(`POST /v1/push/broadcast`), 유저 타겟 푸시(`POST /v1/push/user`) 엔드포인트
- devices/ 모듈 생성: APNs 디바이스 등록(`POST /v1/devices/register`) 엔드포인트
- app.module.ts에 새 모듈들 등록

## Test Plan
- [ ] API 빌드 확인 (Docker)
- [ ] RTC 토큰 발급 API 테스트
- [ ] Push API 테스트
- [ ] 디바이스 등록 API 테스트

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)