### PR TITLE
refactor(api): 관리자 모듈 분리 (admin) (#52)

### DIFF
--- a/api/src/admin/admin.module.ts
+++ b/api/src/admin/admin.module.ts
@@ -1,0 +1,37 @@
+import { Module } from '@nestjs/common';
+import { MulterModule } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
+import { AdminAuthController } from './auth/admin-auth.controller';
+import { AdminAuthService } from './auth/admin-auth.service';
+import { DashboardController } from './dashboard/dashboard.controller';
+import { WardsManagementController } from './wards-management/wards-management.controller';
+import { LocationsController } from './locations/locations.controller';
+import { EmergenciesController } from './emergencies/emergencies.controller';
+import { AppService } from '../app.service';
+import { AuthService } from '../auth/auth.service';
+import { DbService } from '../db.service';
+import { PushService } from '../push.service';
+
+@Module({
+  imports: [
+    MulterModule.register({
+      storage: memoryStorage(),
+    }),
+  ],
+  controllers: [
+    AdminAuthController,
+    DashboardController,
+    WardsManagementController,
+    LocationsController,
+    EmergenciesController,
+  ],
+  providers: [
+    AdminAuthService,
+    AppService,
+    AuthService,
+    DbService,
+    PushService,
+  ],
+  exports: [AdminAuthService],
+})
+export class AdminModule {}

--- a/api/src/admin/auth/admin-auth.controller.ts
+++ b/api/src/admin/auth/admin-auth.controller.ts
@@ -1,0 +1,344 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Body,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { AdminAuthService } from './admin-auth.service';
+import { AuthService } from '../../auth/auth.service';
+import { DbService } from '../../db.service';
+
+@Controller('admin')
+export class AdminAuthController {
+  private readonly logger = new Logger(AdminAuthController.name);
+
+  constructor(
+    private readonly adminAuthService: AdminAuthService,
+    private readonly authService: AuthService,
+    private readonly dbService: DbService,
+  ) {}
+
+  @Post('auth/oauth/code')
+  async oauthCodeExchange(
+    @Body() body: { provider?: string; code?: string; redirectUri?: string },
+  ) {
+    const provider = body.provider?.trim().toLowerCase();
+    const code = body.code?.trim();
+    const redirectUri = body.redirectUri?.trim();
+
+    if (!provider || !code || !redirectUri) {
+      throw new HttpException(
+        'provider, code, and redirectUri are required',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (provider !== 'kakao' && provider !== 'google') {
+      throw new HttpException(
+        'provider must be kakao or google',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    this.logger.log(`oauthCodeExchange provider=${provider}`);
+
+    try {
+      const accessToken = await this.adminAuthService.exchangeCodeForToken(provider, code, redirectUri);
+      const oauthUser = await this.adminAuthService.verifyOAuthToken(provider, accessToken);
+      return await this.adminAuthService.processOAuthLogin(oauthUser, provider);
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(`oauthCodeExchange failed error=${(error as Error).message}`);
+      throw new HttpException(
+        'OAuth 인증에 실패했습니다.',
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+  }
+
+  @Post('auth/oauth')
+  async oauthLogin(
+    @Body() body: { provider?: string; accessToken?: string },
+  ) {
+    const provider = body.provider?.trim().toLowerCase();
+    const accessToken = body.accessToken?.trim();
+
+    if (!provider || !accessToken) {
+      throw new HttpException(
+        'provider and accessToken are required',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (provider !== 'kakao' && provider !== 'google') {
+      throw new HttpException(
+        'provider must be kakao or google',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    this.logger.log(`oauthLogin provider=${provider}`);
+
+    try {
+      const oauthUser = await this.adminAuthService.verifyOAuthToken(provider, accessToken);
+      return await this.adminAuthService.processOAuthLogin(oauthUser, provider);
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(`oauthLogin failed error=${(error as Error).message}`);
+      throw new HttpException(
+        'OAuth 인증에 실패했습니다.',
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+  }
+
+  @Post('auth/refresh')
+  async refreshToken(
+    @Body() body: { refreshToken?: string },
+  ) {
+    const refreshToken = body.refreshToken?.trim();
+
+    if (!refreshToken) {
+      throw new HttpException(
+        'refreshToken is required',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    try {
+      const tokenHash = this.authService.hashToken(refreshToken);
+      const storedToken = await this.dbService.findAdminRefreshToken(tokenHash);
+
+      if (!storedToken) {
+        throw new HttpException(
+          '유효하지 않은 리프레시 토큰입니다.',
+          HttpStatus.UNAUTHORIZED,
+        );
+      }
+
+      const admin = await this.dbService.findAdminById(storedToken.admin_id);
+      if (!admin || !admin.is_active) {
+        await this.dbService.deleteAdminRefreshToken(tokenHash);
+        throw new HttpException(
+          '계정이 비활성화되었습니다.',
+          HttpStatus.FORBIDDEN,
+        );
+      }
+
+      await this.dbService.deleteAdminRefreshToken(tokenHash);
+
+      const jwtPayload = {
+        sub: admin.id,
+        email: admin.email,
+        role: admin.role,
+        type: 'admin',
+      };
+
+      const newAccessToken = this.authService.signAdminAccessToken(jwtPayload);
+      const newRefreshToken = this.authService.signAdminRefreshToken(jwtPayload);
+
+      const newTokenHash = this.authService.hashToken(newRefreshToken);
+      const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+      await this.dbService.createAdminRefreshToken(admin.id, newTokenHash, expiresAt);
+
+      this.logger.log(`refreshToken success adminId=${admin.id}`);
+
+      return {
+        accessToken: newAccessToken,
+        refreshToken: newRefreshToken,
+      };
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(`refreshToken failed error=${(error as Error).message}`);
+      throw new HttpException(
+        '토큰 갱신에 실패했습니다.',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  @Post('auth/logout')
+  async logout(
+    @Body() body: { refreshToken?: string },
+  ) {
+    const refreshToken = body.refreshToken?.trim();
+
+    if (refreshToken) {
+      const tokenHash = this.authService.hashToken(refreshToken);
+      await this.dbService.deleteAdminRefreshToken(tokenHash);
+    }
+
+    return { success: true };
+  }
+
+  @Get('organizations')
+  async listOrganizations() {
+    const organizations = await this.dbService.listAllOrganizations();
+    return {
+      organizations: organizations.map((org) => ({
+        id: org.id,
+        name: org.name,
+      })),
+    };
+  }
+
+  @Post('organizations/find-or-create')
+  async findOrCreateOrganization(
+    @Headers('authorization') authorization: string | undefined,
+    @Body() body: { name?: string },
+  ) {
+    const accessToken = authorization?.replace('Bearer ', '').trim();
+    const name = body.name?.trim();
+
+    if (!accessToken) {
+      throw new HttpException(
+        'Authorization header is required',
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+
+    if (!name) {
+      throw new HttpException(
+        'name is required',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    try {
+      this.authService.verifyAdminAccessToken(accessToken);
+    } catch {
+      throw new HttpException('Invalid token', HttpStatus.UNAUTHORIZED);
+    }
+
+    const result = await this.dbService.findOrCreateOrganization(name);
+    this.logger.log(`findOrCreateOrganization name=${name} created=${result.created}`);
+
+    return {
+      organization: {
+        id: result.organization.id,
+        name: result.organization.name,
+      },
+      created: result.created,
+    };
+  }
+
+  @Put('me/organization')
+  async updateOrganization(
+    @Headers('authorization') authorization: string | undefined,
+    @Body() body: { organizationId?: string },
+  ) {
+    const accessToken = authorization?.replace('Bearer ', '').trim();
+    const organizationId = body.organizationId?.trim();
+
+    if (!accessToken) {
+      throw new HttpException(
+        'Authorization header is required',
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+
+    if (!organizationId) {
+      throw new HttpException(
+        'organizationId is required',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    try {
+      const payload = this.authService.verifyAdminAccessToken(accessToken);
+      const admin = await this.dbService.findAdminById(payload.sub);
+
+      if (!admin || !admin.is_active) {
+        throw new HttpException(
+          '계정을 찾을 수 없거나 비활성화되었습니다.',
+          HttpStatus.FORBIDDEN,
+        );
+      }
+
+      const organization = await this.dbService.findOrganization(organizationId);
+      if (!organization) {
+        throw new HttpException(
+          '조직을 찾을 수 없습니다.',
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      await this.dbService.updateAdminOrganization(admin.id, organizationId);
+      this.logger.log(`updateOrganization adminId=${admin.id} organizationId=${organizationId}`);
+
+      return {
+        success: true,
+        organization: {
+          id: organization.id,
+          name: organization.name,
+        },
+      };
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      throw new HttpException(
+        '조직 선택에 실패했습니다.',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  @Get('me')
+  async getMe(
+    @Headers('authorization') authorization: string | undefined,
+  ) {
+    const accessToken = authorization?.replace('Bearer ', '').trim();
+
+    if (!accessToken) {
+      throw new HttpException(
+        'Authorization header is required',
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+
+    try {
+      const payload = this.authService.verifyAdminAccessToken(accessToken);
+      const admin = await this.dbService.findAdminById(payload.sub);
+
+      if (!admin || !admin.is_active) {
+        throw new HttpException(
+          '계정을 찾을 수 없거나 비활성화되었습니다.',
+          HttpStatus.FORBIDDEN,
+        );
+      }
+
+      const permissions = await this.dbService.getAdminPermissions(admin.id);
+
+      return {
+        admin: {
+          id: admin.id,
+          email: admin.email,
+          name: admin.name,
+          role: admin.role,
+          organizationId: admin.organization_id,
+          permissions,
+        },
+      };
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      throw new HttpException(
+        '인증에 실패했습니다.',
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+  }
+}

--- a/api/src/admin/auth/admin-auth.service.ts
+++ b/api/src/admin/auth/admin-auth.service.ts
@@ -1,0 +1,196 @@
+import { Injectable, HttpException, HttpStatus, Logger } from '@nestjs/common';
+import { AuthService } from '../../auth/auth.service';
+import { DbService } from '../../db.service';
+
+@Injectable()
+export class AdminAuthService {
+  private readonly logger = new Logger(AdminAuthService.name);
+
+  constructor(
+    private readonly authService: AuthService,
+    private readonly dbService: DbService,
+  ) {}
+
+  async verifyOAuthToken(
+    provider: string,
+    accessToken: string,
+  ): Promise<{ providerId: string; email?: string; name?: string }> {
+    if (provider === 'kakao') {
+      return this.verifyKakaoToken(accessToken);
+    } else if (provider === 'google') {
+      return this.verifyGoogleToken(accessToken);
+    }
+    throw new Error(`Unknown provider: ${provider}`);
+  }
+
+  private async verifyKakaoToken(accessToken: string) {
+    const response = await fetch('https://kapi.kakao.com/v2/user/me', {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (!response.ok) {
+      throw new Error('Kakao token verification failed');
+    }
+
+    const data = await response.json();
+    return {
+      providerId: String(data.id),
+      email: data.kakao_account?.email,
+      name: data.properties?.nickname,
+    };
+  }
+
+  private async verifyGoogleToken(accessToken: string) {
+    const response = await fetch('https://www.googleapis.com/oauth2/v3/userinfo', {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (!response.ok) {
+      throw new Error('Google token verification failed');
+    }
+
+    const data = await response.json();
+    return {
+      providerId: data.sub,
+      email: data.email,
+      name: data.name,
+    };
+  }
+
+  async exchangeCodeForToken(
+    provider: string,
+    code: string,
+    redirectUri: string,
+  ): Promise<string> {
+    if (provider === 'kakao') {
+      const clientId = process.env.KAKAO_CLIENT_ID;
+      const clientSecret = process.env.KAKAO_CLIENT_SECRET;
+
+      if (!clientId) {
+        throw new Error('KAKAO_CLIENT_ID not configured');
+      }
+
+      const params = new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        code,
+      });
+
+      if (clientSecret) {
+        params.append('client_secret', clientSecret);
+      }
+
+      const response = await fetch('https://kauth.kakao.com/oauth/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params,
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        this.logger.warn(`Kakao token exchange failed: ${JSON.stringify(data)}`);
+        throw new Error(`Kakao token exchange failed: ${data.error_description || data.error}`);
+      }
+
+      return data.access_token;
+    } else if (provider === 'google') {
+      const clientId = process.env.GOOGLE_CLIENT_ID;
+      const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+
+      if (!clientId || !clientSecret) {
+        throw new Error('GOOGLE_CLIENT_ID or GOOGLE_CLIENT_SECRET not configured');
+      }
+
+      const response = await fetch('https://oauth2.googleapis.com/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          client_id: clientId,
+          client_secret: clientSecret,
+          redirect_uri: redirectUri,
+          code,
+        }),
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        this.logger.warn(`Google token exchange failed: ${JSON.stringify(data)}`);
+        throw new Error(`Google token exchange failed: ${data.error_description || data.error}`);
+      }
+
+      return data.access_token;
+    }
+
+    throw new Error(`Unknown provider: ${provider}`);
+  }
+
+  async processOAuthLogin(oauthUser: { providerId: string; email?: string; name?: string }, provider: string) {
+    if (!oauthUser.email) {
+      throw new HttpException(
+        '이메일 정보를 가져올 수 없습니다. 이메일 제공 동의가 필요합니다.',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    let admin = await this.dbService.findAdminByProviderId(provider, oauthUser.providerId);
+
+    if (!admin) {
+      admin = await this.dbService.findAdminByEmail(oauthUser.email);
+
+      if (admin) {
+        throw new HttpException(
+          `이미 ${admin.provider}로 가입된 계정입니다.`,
+          HttpStatus.CONFLICT,
+        );
+      }
+
+      const newAdmin = await this.dbService.createAdmin({
+        email: oauthUser.email,
+        name: oauthUser.name,
+        provider,
+        providerId: oauthUser.providerId,
+      });
+
+      admin = await this.dbService.findAdminById(newAdmin.id);
+    }
+
+    if (!admin!.is_active) {
+      throw new HttpException(
+        '계정이 비활성화되었습니다. 관리자에게 문의하세요.',
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
+    const jwtPayload = {
+      sub: admin!.id,
+      email: admin!.email,
+      role: admin!.role,
+      type: 'admin',
+    };
+
+    const jwtAccessToken = this.authService.signAdminAccessToken(jwtPayload);
+    const jwtRefreshToken = this.authService.signAdminRefreshToken(jwtPayload);
+
+    const refreshTokenHash = this.authService.hashToken(jwtRefreshToken);
+    const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    await this.dbService.createAdminRefreshToken(admin!.id, refreshTokenHash, expiresAt);
+
+    await this.dbService.updateAdminLastLogin(admin!.id);
+
+    this.logger.log(`OAuth login success adminId=${admin!.id} role=${admin!.role}`);
+
+    return {
+      accessToken: jwtAccessToken,
+      refreshToken: jwtRefreshToken,
+      admin: {
+        id: admin!.id,
+        email: admin!.email,
+        name: admin!.name,
+        role: admin!.role,
+        organizationId: admin!.organization_id,
+      },
+    };
+  }
+}

--- a/api/src/admin/dashboard/dashboard.controller.ts
+++ b/api/src/admin/dashboard/dashboard.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Controller,
+  Get,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { DbService } from '../../db.service';
+
+@Controller('v1/admin/dashboard')
+export class DashboardController {
+  private readonly logger = new Logger(DashboardController.name);
+
+  constructor(private readonly dbService: DbService) {}
+
+  @Get('stats')
+  async getStats() {
+    this.logger.log('getStats called');
+
+    try {
+      const [
+        overview,
+        todayStats,
+        weeklyTrend,
+        moodDistribution,
+        healthAlerts,
+        topKeywords,
+        organizationStats,
+        recentActivity,
+      ] = await Promise.all([
+        this.dbService.getDashboardOverview(),
+        this.dbService.getTodayStats(),
+        this.dbService.getWeeklyTrend(),
+        this.dbService.getMoodDistribution(),
+        this.dbService.getHealthAlertsSummary(),
+        this.dbService.getTopHealthKeywords(10),
+        this.dbService.getOrganizationStats(),
+        this.dbService.getRecentActivity(20),
+      ]);
+
+      return {
+        overview,
+        todayStats,
+        weeklyTrend,
+        moodDistribution,
+        healthAlerts,
+        topKeywords,
+        organizationStats,
+        recentActivity,
+        fetchedAt: new Date().toISOString(),
+      };
+    } catch (error) {
+      this.logger.warn(`getStats failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to fetch dashboard stats', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Get('realtime')
+  async getRealtime() {
+    this.logger.log('getRealtime called');
+
+    try {
+      const [realtime, recentActivity] = await Promise.all([
+        this.dbService.getRealtimeStats(),
+        this.dbService.getRecentActivity(10),
+      ]);
+
+      return {
+        ...realtime,
+        recentActivity,
+        fetchedAt: new Date().toISOString(),
+      };
+    } catch (error) {
+      this.logger.warn(`getRealtime failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to fetch realtime stats', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/api/src/admin/emergencies/emergencies.controller.ts
+++ b/api/src/admin/emergencies/emergencies.controller.ts
@@ -1,0 +1,324 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Param,
+  Body,
+  Query,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { AppService } from '../../app.service';
+import { DbService } from '../../db.service';
+
+@Controller('v1/admin')
+export class EmergenciesController {
+  private readonly logger = new Logger(EmergenciesController.name);
+
+  constructor(
+    private readonly appService: AppService,
+    private readonly dbService: DbService,
+  ) {}
+
+  @Post('emergency')
+  async triggerEmergency(
+    @Headers('authorization') authorization: string | undefined,
+    @Body()
+    body: {
+      wardId?: string;
+      message?: string;
+    },
+  ) {
+    const config = this.appService.getConfig();
+    const auth = this.appService.getAuthContext(authorization);
+    if (config.authRequired && !auth) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    const wardId = body.wardId?.trim();
+    if (!wardId) {
+      throw new HttpException('wardId is required', HttpStatus.BAD_REQUEST);
+    }
+
+    try {
+      const ward = await this.dbService.findWardById(wardId);
+      if (!ward) {
+        throw new HttpException('Ward not found', HttpStatus.NOT_FOUND);
+      }
+
+      const currentLocation = await this.dbService.getWardCurrentLocation(wardId);
+      const latitude = currentLocation ? parseFloat(currentLocation.latitude) : undefined;
+      const longitude = currentLocation ? parseFloat(currentLocation.longitude) : undefined;
+
+      this.logger.log(`triggerEmergency wardId=${wardId}`);
+
+      const emergency = await this.dbService.createEmergency({
+        wardId,
+        type: 'admin',
+        latitude,
+        longitude,
+        message: body.message?.trim(),
+      });
+
+      await this.dbService.updateWardLocationStatus(wardId, 'emergency');
+
+      const nearbyAgencies: Array<{
+        id: string;
+        name: string;
+        type: string;
+        distance: number;
+        contacted: boolean;
+      }> = [];
+
+      if (latitude !== undefined && longitude !== undefined) {
+        const agencies = await this.dbService.findNearbyAgencies(latitude, longitude, 10, 5);
+        for (const agency of agencies) {
+          const distanceKm = parseFloat(agency.distance_km);
+          await this.dbService.createEmergencyContact({
+            emergencyId: emergency.id,
+            agencyId: agency.id,
+            distanceKm,
+            responseStatus: 'pending',
+          });
+          nearbyAgencies.push({
+            id: agency.id,
+            name: agency.name,
+            type: agency.type,
+            distance: Math.round(distanceKm * 10) / 10,
+            contacted: true,
+          });
+        }
+      }
+
+      let guardianNotified = false;
+      const wardInfo = await this.dbService.getWardWithGuardianInfo(wardId);
+      if (wardInfo?.guardian_identity) {
+        try {
+          await this.appService.sendUserPush({
+            identity: wardInfo.guardian_identity,
+            type: 'alert',
+            title: '🚨 비상 알림',
+            body: `관제센터에서 ${wardInfo.ward_name || '피보호자'}님에 대해 비상 상황을 발동했습니다`,
+            payload: {
+              type: 'emergency',
+              emergencyId: emergency.id,
+              wardId,
+            },
+          });
+          await this.dbService.updateEmergencyGuardianNotified(emergency.id);
+          guardianNotified = true;
+        } catch (pushError) {
+          this.logger.warn(`Emergency guardian push failed: ${(pushError as Error).message}`);
+        }
+      }
+
+      return {
+        emergencyId: emergency.id,
+        status: 'dispatched',
+        nearbyAgencies,
+        guardianNotified,
+      };
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.error(`triggerEmergency failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to trigger emergency', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Get('emergencies')
+  async getEmergencies(
+    @Headers('authorization') authorization: string | undefined,
+    @Query('status') status?: string,
+    @Query('wardId') wardId?: string,
+    @Query('limit') limit?: string,
+  ) {
+    const config = this.appService.getConfig();
+    const auth = this.appService.getAuthContext(authorization);
+    if (config.authRequired && !auth) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    const validStatuses = ['active', 'resolved', 'false_alarm'];
+    if (status && !validStatuses.includes(status)) {
+      throw new HttpException(
+        `status must be one of: ${validStatuses.join(', ')}`,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    this.logger.log(`getEmergencies status=${status ?? 'all'} wardId=${wardId ?? 'all'}`);
+
+    try {
+      const emergencies = await this.dbService.getEmergencies({
+        status: status as 'active' | 'resolved' | 'false_alarm' | undefined,
+        wardId: wardId?.trim(),
+        limit: limit ? parseInt(limit, 10) : 50,
+      });
+
+      const emergenciesWithContacts = await Promise.all(
+        emergencies.map(async (e) => {
+          const contacts = await this.dbService.getEmergencyContacts(e.id);
+          return {
+            id: e.id,
+            wardId: e.ward_id,
+            wardName: e.ward_name || '알 수 없음',
+            type: e.type,
+            status: e.status,
+            latitude: e.latitude ? parseFloat(e.latitude) : null,
+            longitude: e.longitude ? parseFloat(e.longitude) : null,
+            message: e.message,
+            guardianNotified: e.guardian_notified,
+            createdAt: e.created_at,
+            resolvedAt: e.resolved_at,
+            respondedAgencies: contacts.map((c) => c.agency_name),
+          };
+        }),
+      );
+
+      return {
+        emergencies: emergenciesWithContacts,
+      };
+    } catch (error) {
+      this.logger.warn(`getEmergencies failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to get emergencies', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Get('emergencies/:id')
+  async getEmergencyDetail(
+    @Headers('authorization') authorization: string | undefined,
+    @Param('id') emergencyId: string,
+  ) {
+    const config = this.appService.getConfig();
+    const auth = this.appService.getAuthContext(authorization);
+    if (config.authRequired && !auth) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    if (!emergencyId?.trim()) {
+      throw new HttpException('emergencyId is required', HttpStatus.BAD_REQUEST);
+    }
+
+    this.logger.log(`getEmergencyDetail emergencyId=${emergencyId}`);
+
+    try {
+      const emergency = await this.dbService.getEmergencyById(emergencyId);
+      if (!emergency) {
+        throw new HttpException('Emergency not found', HttpStatus.NOT_FOUND);
+      }
+
+      const contacts = await this.dbService.getEmergencyContacts(emergencyId);
+
+      return {
+        id: emergency.id,
+        wardId: emergency.ward_id,
+        wardName: emergency.ward_name || '알 수 없음',
+        type: emergency.type,
+        status: emergency.status,
+        latitude: emergency.latitude ? parseFloat(emergency.latitude) : null,
+        longitude: emergency.longitude ? parseFloat(emergency.longitude) : null,
+        message: emergency.message,
+        guardianNotified: emergency.guardian_notified,
+        resolvedAt: emergency.resolved_at,
+        resolvedBy: emergency.resolved_by,
+        resolutionNote: emergency.resolution_note,
+        createdAt: emergency.created_at,
+        contacts: contacts.map((c) => ({
+          id: c.id,
+          agencyId: c.agency_id,
+          agencyName: c.agency_name,
+          agencyType: c.agency_type,
+          distanceKm: parseFloat(c.distance_km),
+          responseStatus: c.response_status,
+          contactedAt: c.contacted_at,
+        })),
+      };
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(`getEmergencyDetail failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to get emergency detail', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Put('emergencies/:id/resolve')
+  async resolveEmergency(
+    @Headers('authorization') authorization: string | undefined,
+    @Param('id') emergencyId: string,
+    @Body()
+    body: {
+      status?: 'resolved' | 'false_alarm';
+      resolutionNote?: string;
+    },
+  ) {
+    const config = this.appService.getConfig();
+    const auth = this.appService.getAuthContext(authorization);
+    if (config.authRequired && !auth) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    if (!emergencyId?.trim()) {
+      throw new HttpException('emergencyId is required', HttpStatus.BAD_REQUEST);
+    }
+
+    const resolveStatus = body.status || 'resolved';
+    if (!['resolved', 'false_alarm'].includes(resolveStatus)) {
+      throw new HttpException(
+        'status must be one of: resolved, false_alarm',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    this.logger.log(`resolveEmergency emergencyId=${emergencyId} status=${resolveStatus}`);
+
+    try {
+      const emergency = await this.dbService.getEmergencyById(emergencyId);
+      if (!emergency) {
+        throw new HttpException('Emergency not found', HttpStatus.NOT_FOUND);
+      }
+
+      if (emergency.status !== 'active') {
+        throw new HttpException('Emergency is already resolved', HttpStatus.BAD_REQUEST);
+      }
+
+      const resolvedBy = auth?.identity || 'admin';
+      let resolvedByUserId: string | null = null;
+      try {
+        const user = await this.dbService.upsertUser(resolvedBy);
+        resolvedByUserId = user.id;
+      } catch {
+        // ignore
+      }
+
+      const resolved = await this.dbService.resolveEmergency({
+        emergencyId,
+        resolvedBy: resolvedByUserId || resolvedBy,
+        status: resolveStatus,
+        resolutionNote: body.resolutionNote?.trim(),
+      });
+
+      if (emergency.ward_id) {
+        await this.dbService.updateWardLocationStatus(emergency.ward_id, 'normal');
+      }
+
+      return {
+        success: true,
+        emergencyId: resolved.id,
+        status: resolved.status,
+        resolvedAt: resolved.resolved_at,
+      };
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(`resolveEmergency failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to resolve emergency', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/api/src/admin/index.ts
+++ b/api/src/admin/index.ts
@@ -1,0 +1,7 @@
+export { AdminModule } from './admin.module';
+export { AdminAuthService } from './auth/admin-auth.service';
+export { AdminAuthController } from './auth/admin-auth.controller';
+export { DashboardController } from './dashboard/dashboard.controller';
+export { WardsManagementController } from './wards-management/wards-management.controller';
+export { LocationsController } from './locations/locations.controller';
+export { EmergenciesController } from './emergencies/emergencies.controller';

--- a/api/src/admin/locations/locations.controller.ts
+++ b/api/src/admin/locations/locations.controller.ts
@@ -1,0 +1,160 @@
+import {
+  Controller,
+  Get,
+  Put,
+  Param,
+  Body,
+  Query,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { AppService } from '../../app.service';
+import { DbService } from '../../db.service';
+
+@Controller('v1/admin/locations')
+export class LocationsController {
+  private readonly logger = new Logger(LocationsController.name);
+
+  constructor(
+    private readonly appService: AppService,
+    private readonly dbService: DbService,
+  ) {}
+
+  @Get()
+  async getLocations(
+    @Headers('authorization') authorization: string | undefined,
+    @Query('organizationId') organizationId?: string,
+  ) {
+    const config = this.appService.getConfig();
+    const auth = this.appService.getAuthContext(authorization);
+    if (config.authRequired && !auth) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    this.logger.log(`getLocations organizationId=${organizationId ?? 'all'}`);
+
+    try {
+      const locations = await this.dbService.getAllWardCurrentLocations(organizationId);
+
+      return {
+        locations: locations.map((loc) => ({
+          wardId: loc.ward_id,
+          wardName: loc.ward_nickname || loc.ward_name || '이름 없음',
+          latitude: parseFloat(loc.latitude),
+          longitude: parseFloat(loc.longitude),
+          accuracy: loc.accuracy ? parseFloat(loc.accuracy) : null,
+          lastUpdated: loc.last_updated,
+          status: loc.status,
+          organizationId: loc.organization_id,
+        })),
+      };
+    } catch (error) {
+      this.logger.warn(`getLocations failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to get locations', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Get(':wardId/history')
+  async getLocationHistory(
+    @Headers('authorization') authorization: string | undefined,
+    @Param('wardId') wardId: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+    @Query('limit') limit?: string,
+  ) {
+    const config = this.appService.getConfig();
+    const auth = this.appService.getAuthContext(authorization);
+    if (config.authRequired && !auth) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    if (!wardId?.trim()) {
+      throw new HttpException('wardId is required', HttpStatus.BAD_REQUEST);
+    }
+
+    this.logger.log(`getLocationHistory wardId=${wardId} from=${from ?? 'none'} to=${to ?? 'none'}`);
+
+    try {
+      const ward = await this.dbService.findWardById(wardId);
+      if (!ward) {
+        throw new HttpException('Ward not found', HttpStatus.NOT_FOUND);
+      }
+
+      const history = await this.dbService.getWardLocationHistory({
+        wardId,
+        from: from ? new Date(from) : undefined,
+        to: to ? new Date(to) : undefined,
+        limit: limit ? parseInt(limit, 10) : 100,
+      });
+
+      return {
+        wardId,
+        history: history.map((loc) => ({
+          latitude: parseFloat(loc.latitude),
+          longitude: parseFloat(loc.longitude),
+          accuracy: loc.accuracy ? parseFloat(loc.accuracy) : null,
+          timestamp: loc.recorded_at,
+        })),
+      };
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(`getLocationHistory failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to get location history', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Put(':wardId/status')
+  async updateLocationStatus(
+    @Headers('authorization') authorization: string | undefined,
+    @Param('wardId') wardId: string,
+    @Body() body: { status?: string },
+  ) {
+    const config = this.appService.getConfig();
+    const auth = this.appService.getAuthContext(authorization);
+    if (config.authRequired && !auth) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    if (!wardId?.trim()) {
+      throw new HttpException('wardId is required', HttpStatus.BAD_REQUEST);
+    }
+
+    const status = body.status?.trim();
+    if (!status || !['normal', 'warning', 'emergency'].includes(status)) {
+      throw new HttpException(
+        'status must be one of: normal, warning, emergency',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    this.logger.log(`updateLocationStatus wardId=${wardId} status=${status}`);
+
+    try {
+      const ward = await this.dbService.findWardById(wardId);
+      if (!ward) {
+        throw new HttpException('Ward not found', HttpStatus.NOT_FOUND);
+      }
+
+      await this.dbService.updateWardLocationStatus(
+        wardId,
+        status as 'normal' | 'warning' | 'emergency',
+      );
+
+      return {
+        success: true,
+        wardId,
+        status,
+      };
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(`updateLocationStatus failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to update status', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/api/src/admin/wards-management/wards-management.controller.ts
+++ b/api/src/admin/wards-management/wards-management.controller.ts
@@ -1,0 +1,195 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Logger,
+  UseInterceptors,
+  UploadedFile,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { parse } from 'csv-parse/sync';
+import { AppService } from '../../app.service';
+import { AuthService } from '../../auth/auth.service';
+import { DbService } from '../../db.service';
+
+@Controller('v1/admin')
+export class WardsManagementController {
+  private readonly logger = new Logger(WardsManagementController.name);
+
+  constructor(
+    private readonly appService: AppService,
+    private readonly authService: AuthService,
+    private readonly dbService: DbService,
+  ) {}
+
+  private isValidEmail(email: string): boolean {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  }
+
+  @Post('wards/bulk-upload')
+  @UseInterceptors(FileInterceptor('file'))
+  async bulkUploadWards(
+    @Headers('authorization') authorization: string | undefined,
+    @UploadedFile() file: Express.Multer.File,
+    @Body() body: { organizationId?: string },
+  ) {
+    const config = this.appService.getConfig();
+    const auth = this.appService.getAuthContext(authorization);
+    if (config.authRequired && !auth) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    let adminId: string | undefined;
+    if (authorization?.startsWith('Bearer ')) {
+      try {
+        const tokenPayload = this.authService.verifyAdminAccessToken(authorization.slice(7));
+        adminId = tokenPayload.sub;
+      } catch {
+        // Non-admin token, continue without admin ID
+      }
+    }
+
+    if (!file) {
+      throw new HttpException('file is required', HttpStatus.BAD_REQUEST);
+    }
+
+    const organizationId = body.organizationId?.trim();
+    if (!organizationId) {
+      throw new HttpException('organizationId is required', HttpStatus.BAD_REQUEST);
+    }
+
+    const maxSize = 5 * 1024 * 1024;
+    if (file.size > maxSize) {
+      throw new HttpException('File size exceeds 5MB limit', HttpStatus.BAD_REQUEST);
+    }
+
+    const organization = await this.dbService.findOrganization(organizationId);
+    if (!organization) {
+      throw new HttpException('Organization not found', HttpStatus.NOT_FOUND);
+    }
+
+    this.logger.log(`bulkUploadWards organizationId=${organizationId} adminId=${adminId ?? 'none'} fileSize=${file.size}`);
+
+    try {
+      const records = parse(file.buffer, {
+        columns: true,
+        skip_empty_lines: true,
+        trim: true,
+      }) as Array<{
+        email?: string;
+        phone_number?: string;
+        name?: string;
+        birth_date?: string;
+        address?: string;
+        notes?: string;
+      }>;
+
+      const results = {
+        total: records.length,
+        created: 0,
+        skipped: 0,
+        failed: 0,
+        errors: [] as Array<{ row: number; email: string; reason: string }>,
+      };
+
+      for (let i = 0; i < records.length; i++) {
+        const record = records[i];
+        const row = i + 2;
+        const email = record.email?.trim() ?? '';
+
+        try {
+          if (!email || !this.isValidEmail(email)) {
+            throw new Error('잘못된 이메일 형식');
+          }
+          if (!record.phone_number?.trim()) {
+            throw new Error('전화번호 필수');
+          }
+          if (!record.name?.trim()) {
+            throw new Error('이름 필수');
+          }
+
+          const existing = await this.dbService.findOrganizationWard(organizationId, email);
+          if (existing) {
+            results.skipped++;
+            continue;
+          }
+
+          await this.dbService.createOrganizationWard({
+            organizationId,
+            email,
+            phoneNumber: record.phone_number.trim(),
+            name: record.name.trim(),
+            birthDate: record.birth_date?.trim() || null,
+            address: record.address?.trim() || null,
+            uploadedByAdminId: adminId,
+            notes: record.notes?.trim() || undefined,
+          });
+
+          results.created++;
+        } catch (error) {
+          results.failed++;
+          results.errors.push({
+            row,
+            email,
+            reason: (error as Error).message,
+          });
+        }
+      }
+
+      this.logger.log(
+        `bulkUploadWards completed organizationId=${organizationId} adminId=${adminId ?? 'none'} total=${results.total} created=${results.created} skipped=${results.skipped} failed=${results.failed}`,
+      );
+
+      return {
+        success: true,
+        ...results,
+      };
+    } catch (error) {
+      this.logger.error(`bulkUploadWards failed error=${(error as Error).message}`);
+      throw new HttpException('Failed to process CSV file', HttpStatus.BAD_REQUEST);
+    }
+  }
+
+  @Get('my-wards')
+  async getMyManagedWards(
+    @Headers('authorization') authorization: string | undefined,
+  ) {
+    if (!authorization?.startsWith('Bearer ')) {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    }
+
+    const tokenPayload = this.authService.verifyAdminAccessToken(authorization.slice(7));
+    const adminId = tokenPayload.sub;
+
+    const [wards, stats] = await Promise.all([
+      this.dbService.getMyManagedWards(adminId),
+      this.dbService.getMyManagedWardsStats(adminId),
+    ]);
+
+    return {
+      wards: wards.map((w) => ({
+        id: w.id,
+        organizationId: w.organization_id,
+        organizationName: w.organization_name,
+        email: w.email,
+        phoneNumber: w.phone_number,
+        name: w.name,
+        birthDate: w.birth_date,
+        address: w.address,
+        notes: w.notes,
+        isRegistered: w.is_registered,
+        wardId: w.ward_id,
+        createdAt: w.created_at,
+        lastCallAt: w.last_call_at,
+        totalCalls: parseInt(w.total_calls || '0', 10),
+        lastMood: w.last_mood,
+      })),
+      stats,
+    };
+  }
+}

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -15,6 +15,7 @@ import { CallsModule } from './calls/calls.module';
 import { RtcModule } from './rtc/rtc.module';
 import { DevicesModule } from './devices/devices.module';
 import { PushModule } from './push/push.module';
+import { AdminModule } from './admin/admin.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { PushModule } from './push/push.module';
     RtcModule,
     DevicesModule,
     PushModule,
+    AdminModule,
   ],
   controllers: [AppController],
   providers: [


### PR DESCRIPTION
## Summary
- admin/auth/ 생성: OAuth 인증(Kakao/Google), 토큰 갱신, 로그아웃, 조직 관리
- admin/dashboard/ 생성: 대시보드 통계, 실시간 통계 API
- admin/wards-management/ 생성: CSV 일괄 등록, 내가 관리하는 피보호자 조회
- admin/locations/ 생성: 전체 위치 조회, 이력, 상태 업데이트
- admin/emergencies/ 생성: 비상 상황 생성/조회/상세/해결
- AdminAuthService: OAuth 검증 로직 분리 (verifyOAuthToken, exchangeCodeForToken)

## Endpoints migrated
- `POST admin/auth/oauth/code` - OAuth code → token 교환
- `POST admin/auth/oauth` - OAuth 직접 로그인
- `POST admin/auth/refresh` - 토큰 갱신
- `POST admin/auth/logout` - 로그아웃
- `GET admin/organizations` - 조직 목록
- `POST admin/organizations/find-or-create` - 조직 조회/생성
- `PUT admin/me/organization` - 관리자 조직 설정
- `GET admin/me` - 현재 관리자 정보
- `GET v1/admin/dashboard/stats` - 대시보드 통계
- `GET v1/admin/dashboard/realtime` - 실시간 통계
- `POST v1/admin/wards/bulk-upload` - CSV 일괄 등록
- `GET v1/admin/my-wards` - 내가 관리하는 피보호자
- `GET v1/admin/locations` - 전체 위치
- `GET v1/admin/locations/:wardId/history` - 위치 이력
- `PUT v1/admin/locations/:wardId/status` - 위치 상태 업데이트
- `POST v1/admin/emergency` - 비상 상황 발동
- `GET v1/admin/emergencies` - 비상 상황 목록
- `GET v1/admin/emergencies/:id` - 비상 상황 상세
- `PUT v1/admin/emergencies/:id/resolve` - 비상 상황 해결

## Test Plan
- [ ] API 빌드 확인 (Docker)
- [ ] 관리자 OAuth 로그인 테스트
- [ ] 대시보드 통계 API 테스트
- [ ] 비상 상황 API 테스트

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)